### PR TITLE
Store rollouts posted to DevTaskLoader

### DIFF
--- a/agentlightning/client.py
+++ b/agentlightning/client.py
@@ -294,6 +294,14 @@ class DevTaskLoader(AgentLightningClient):
         else:
             self._resources_update = ResourcesUpdate(resources_id="local", resources=resources)
 
+        # Store rollouts posted back to the loader for easy debugging of local runs
+        self._posted_rollouts: List[Rollout] = []
+
+    @property
+    def posted_rollouts(self) -> List[Rollout]:
+        """Return rollouts that have been posted back to the loader."""
+        return self._posted_rollouts
+
     def poll_next_task(self) -> Task:
         """Returns the next task from the local queue.
 
@@ -338,6 +346,7 @@ class DevTaskLoader(AgentLightningClient):
 
     def post_rollout(self, rollout: Rollout) -> Optional[Dict[str, Any]]:
         logger.debug(f"DevTaskLoader received rollout for task: {rollout.rollout_id}")
+        self._posted_rollouts.append(rollout)
         return {"status": "received", "rollout_id": rollout.rollout_id}
 
     async def poll_next_task_async(self) -> Task:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -316,6 +316,8 @@ def test_local_client_core_functionality(sample_resources: NamedResources):
     assert result is not None
     assert result["status"] == "received"
     assert result["rollout_id"] == "test_rollout"
+    assert len(client2.posted_rollouts) == 1
+    assert client2.posted_rollouts[0].rollout_id == "test_rollout"
 
     # Test repr
     repr_str = repr(client2)
@@ -368,3 +370,5 @@ async def test_local_client_async_methods(sample_resources: NamedResources):
     result = await client.post_rollout_async(rollout)
     assert result is not None
     assert result["rollout_id"] == "async_rollout"
+    assert len(client.posted_rollouts) == 1
+    assert client.posted_rollouts[0].final_reward == 0.8


### PR DESCRIPTION
## Summary
- keep a list of posted rollouts in `DevTaskLoader`
- expose the list via `posted_rollouts` property
- update local client tests to assert rollouts are stored
- revert earlier changes that skipped `examples/calc_x/test_agentops.py`

## Testing
- `pre-commit run --files agentlightning/client.py tests/test_client.py examples/calc_x/test_agentops.py`
- `pytest -q tests/test_client.py`


------
https://chatgpt.com/codex/tasks/task_e_6882139f1b54832e87d9a5c487aec387