### PR TITLE
Support agent lifecycle in trainer

### DIFF
--- a/agentlightning/litagent.py
+++ b/agentlightning/litagent.py
@@ -4,7 +4,15 @@ import logging
 import weakref
 from typing import Any, List, Dict, Union, Optional, TYPE_CHECKING
 
-from .types import NamedResources, Rollout, Task, TaskInput, Triplet, RolloutRawResult
+from .types import (
+    NamedResources,
+    Rollout,
+    Task,
+    TaskInput,
+    Triplet,
+    RolloutRawResult,
+    ParallelWorkerBase,
+)
 
 if TYPE_CHECKING:
     from .trainer import Trainer
@@ -15,7 +23,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class LitAgent:
+class LitAgent(ParallelWorkerBase):
     """Base class for the training and validation logic of an agent.
 
     Developers should subclass this class and implement the rollout methods
@@ -32,6 +40,7 @@ class LitAgent:
             trained_agents: Optional string representing the trained agents.
                             This can be used to track which agents have been trained by this instance.
         """
+        super().__init__()
         self.trained_agents = trained_agents
         self._trainer_ref: weakref.ReferenceType[Trainer] | None = None
         self._runner_ref: weakref.ReferenceType[AgentRunner] | None = None


### PR DESCRIPTION
## Summary
- make `LitAgent` a `ParallelWorkerBase`
- initialize and teardown `LitAgent` within `Trainer`
- ensure workers call agent `init_worker` and `teardown_worker`
- move agent lifecycle calls to `Trainer.init` and `Trainer.teardown`
- move `agent.set_trainer` to `init_worker`

## Testing
- `pre-commit run --files agentlightning/trainer.py agentlightning/litagent.py`
- `pytest -q` *(fails: connection refused when tests try to upload logs)*

------
https://chatgpt.com/codex/tasks/task_e_688c4d88f110832eaee2dccb73595b57