### PR TITLE
Disable HTTP tracer tests

### DIFF
--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -842,16 +842,7 @@ def test_run_with_agentops_tracer(agent_func):
 
 @pytest.mark.parametrize("agent_func", list(iterate_over_agents()), ids=lambda f: f.__name__)
 def test_run_with_http_tracer(agent_func):
-    if "mcp" in agent_func.__name__:
-        pytest.skip("MCP server is not yet supported with HTTP tracer")
-    if "openai_agents_sdk" in agent_func.__name__:
-        pytest.skip("OpenAI Agents SDK is not yet supported with HTTP tracer")
-    if "langchain_tooluse" in agent_func.__name__:
-        pytest.skip("LangChain tool use sometimes timeouts with HTTP tracer")
-    if "langgraph" in agent_func.__name__:
-        pytest.skip("LangGraph is not yet supported with HTTP tracer")
-    if "autogen" in agent_func.__name__:
-        pytest.skip("AutoGen is not yet supported with HTTP tracer")
+    pytest.skip("HTTP tracer tests are disabled for now due to issues on GitHub Actions.")
 
     import httpdbg.hooks.all
 


### PR DESCRIPTION
This pull request simplifies the `test_run_with_http_tracer` test in `tests/test_tracer.py` by skipping all HTTP tracer tests unconditionally, rather than skipping them only for specific agent types.

Testing changes:

* Updated the `test_run_with_http_tracer` function to skip all tests for the HTTP tracer due to ongoing issues on GitHub Actions, instead of skipping only for certain agent implementations.