### PR TITLE
docs: add Discord community badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@
 [![GPU Test](https://github.com/microsoft/agent-lightning/actions/workflows/examples.yml/badge.svg)](https://github.com/microsoft/agent-lightning/actions/workflows/examples.yml)
 [![PyPI version](https://badge.fury.io/py/agentlightning.svg)](https://badge.fury.io/py/agentlightning)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/fgnSS4r4yy)
 
 **The absolute trainer to light up AI agents.**
+
+Join our [Discord community](https://discord.gg/fgnSS4r4yy) to connect with other users and contributors.
 
 ## ⚡ Core Features
 


### PR DESCRIPTION
## Summary
- add Discord badge linking to invite
- mention Discord community in README

## Testing
- `pre-commit run --files README.md`
- `pytest` *(fails: ImportError: cannot import name 'ChatCompletionMessageFunctionToolCallParam')*

------
https://chatgpt.com/codex/tasks/task_e_689cb590455c832eaadc2ede323df070