### PR TITLE
Fix RAGAgent initialization

### DIFF
--- a/examples/rag/rag_agent.py
+++ b/examples/rag/rag_agent.py
@@ -6,7 +6,7 @@ import shutil
 import sys
 import tempfile
 import time
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 import dotenv
 import termcolor
@@ -50,7 +50,8 @@ Repeat as needed. When done, wrap your final, concise answer in <answer> tags.""
 
 
 class RAGAgent(LitAgent):
-    def __init__(self):
+    def __init__(self, trained_agents: str | None = None) -> None:
+        super().__init__(trained_agents=trained_agents)
         self.mcp_server_url = "http://127.0.0.1:8099/sse"
 
     async def training_rollout_async(self, task: Any, rollout_id: str, resources: NamedResources) -> Any:


### PR DESCRIPTION
## Summary
- Call super().__init__ in RAGAgent and allow passing `trained_agents`

## Testing
- `pre-commit run --files examples/rag/rag_agent.py`
- `pytest` *(fails: ImportError: cannot import name 'ChatCompletionMessageFunctionToolCallParam' from 'openai.types.chat')*

------
https://chatgpt.com/codex/tasks/task_e_689cbf063e28832ebc808749975f342b