### PR TITLE
docs: update Discord invitation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 [![GPU Test](https://github.com/microsoft/agent-lightning/actions/workflows/examples.yml/badge.svg)](https://github.com/microsoft/agent-lightning/actions/workflows/examples.yml)
 [![PyPI version](https://badge.fury.io/py/agentlightning.svg)](https://badge.fury.io/py/agentlightning)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/UScU7kyr)
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/RYk7CdvDR7)
 
 **The absolute trainer to light up AI agents.**
 
-Join our [Discord community](https://discord.gg/UScU7kyr) to connect with other users and contributors.
+Join our [Discord community](https://discord.gg/RYk7CdvDR7) to connect with other users and contributors.
 
 ## ⚡ Core Features
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Agent Lightning is the absolute trainer to light up AI agents.
 - [Quickstart](quickstart/getting-started.md) - Learn the fundamentals of Agent Lightning
 - [Train SQL Agent with RL](how-to/train-sql-agent.md) - A practical example of training a SQL agent
 - [API Reference](reference/core.md) - Complete API documentation
-- [Join our Discord community](https://discord.gg/UScU7kyr) - Connect with other users and contributors
+- [Join our Discord community](https://discord.gg/RYk7CdvDR7) - Connect with other users and contributors
 
 
 ## Resources


### PR DESCRIPTION
## Summary
- update Discord invite link in README and docs

## Testing
- `uv run pre-commit run --files README.md docs/index.md`
- `uv run pytest` *(fails: ImportError: cannot import name 'ChatCompletionMessageFunctionToolCallParam' from 'openai.types.chat')*


------
https://chatgpt.com/codex/tasks/task_e_689d57dadc9c832e9d99891740bd0504