### PR TITLE
Add batch rollout helpers and multi-task queueing

### DIFF
--- a/agentlightning/litagent.py
+++ b/agentlightning/litagent.py
@@ -139,6 +139,50 @@ class LitAgent:
         """
         return self.training_rollout(task, rollout_id, resources)
 
+    def training_rollout_batch(
+        self,
+        tasks: List[TaskInput],
+        rollout_ids: List[str],
+        resources_list: List[NamedResources],
+    ) -> List[RolloutRawResult]:
+        """Executes training rollouts for a batch of tasks.
+
+        By default, this method iterates over ``tasks`` and delegates to
+        :meth:`training_rollout` for each corresponding ``rollout_id`` with its
+        matching resources.
+
+        Args:
+            tasks: A list of task inputs.
+            rollout_ids: A list of rollout identifiers matching ``tasks``.
+            resources_list: A list of named resources for each rollout.
+
+        Returns:
+            A list containing the result of each individual rollout.
+        """
+        return [self.training_rollout(t, rid, res) for t, rid, res in zip(tasks, rollout_ids, resources_list)]
+
+    def validation_rollout_batch(
+        self,
+        tasks: List[TaskInput],
+        rollout_ids: List[str],
+        resources_list: List[NamedResources],
+    ) -> List[RolloutRawResult]:
+        """Executes validation rollouts for a batch of tasks.
+
+        By default, this method delegates to :meth:`validation_rollout` for each
+        task, which itself falls back to :meth:`training_rollout` unless
+        overridden.
+
+        Args:
+            tasks: A list of task inputs.
+            rollout_ids: A list of rollout identifiers matching ``tasks``.
+            resources_list: A list of named resources for each rollout.
+
+        Returns:
+            A list containing the result of each individual validation rollout.
+        """
+        return [self.validation_rollout(t, rid, res) for t, rid, res in zip(tasks, rollout_ids, resources_list)]
+
     async def training_rollout_async(
         self, task: TaskInput, rollout_id: str, resources: NamedResources
     ) -> RolloutRawResult:
@@ -176,3 +220,51 @@ class LitAgent:
             The result of the asynchronous validation rollout.
         """
         return await self.training_rollout_async(task, rollout_id, resources)
+
+    async def training_rollout_batch_async(
+        self,
+        tasks: List[TaskInput],
+        rollout_ids: List[str],
+        resources_list: List[NamedResources],
+    ) -> List[RolloutRawResult]:
+        """Asynchronous version of :meth:`training_rollout_batch`.
+
+        By default, this method awaits :meth:`training_rollout_async` for each
+        item in ``tasks`` sequentially with its matching resources.
+
+        Args:
+            tasks: A list of task inputs.
+            rollout_ids: A list of rollout identifiers matching ``tasks``.
+            resources_list: A list of named resources for each rollout.
+
+        Returns:
+            A list containing the result of each individual rollout.
+        """
+        return [
+            await self.training_rollout_async(t, rid, res) for t, rid, res in zip(tasks, rollout_ids, resources_list)
+        ]
+
+    async def validation_rollout_batch_async(
+        self,
+        tasks: List[TaskInput],
+        rollout_ids: List[str],
+        resources_list: List[NamedResources],
+    ) -> List[RolloutRawResult]:
+        """Asynchronous version of :meth:`validation_rollout_batch`.
+
+        By default, this method awaits :meth:`validation_rollout_async` for each
+        task. Since :meth:`validation_rollout_async` redirects to
+        :meth:`training_rollout_async` unless overridden, this batch method will
+        also use :meth:`training_rollout_async` by default.
+
+        Args:
+            tasks: A list of task inputs.
+            rollout_ids: A list of rollout identifiers matching ``tasks``.
+            resources_list: A list of named resources for each rollout.
+
+        Returns:
+            A list containing the result of each individual validation rollout.
+        """
+        return [
+            await self.validation_rollout_async(t, rid, res) for t, rid, res in zip(tasks, rollout_ids, resources_list)
+        ]

--- a/agentlightning/trainer.py
+++ b/agentlightning/trainer.py
@@ -50,6 +50,7 @@ class Trainer(ParallelWorkerBase):
         n_workers: int = 1,
         max_tasks: Optional[int] = None,
         daemon: bool = True,
+        batch_size: int = 1,
         tracer: Union[BaseTracer, str, dict, None] = None,
         triplet_exporter: Union[TripletExporter, dict, None] = None,
     ):
@@ -58,6 +59,7 @@ class Trainer(ParallelWorkerBase):
         self.max_tasks = max_tasks
         self.daemon = daemon
         self.dev = dev
+        self.batch_size = batch_size
         self._client: AgentLightningClient | None = None  # Will be initialized in fit method
 
         self.tracer = self._make_tracer(tracer)
@@ -181,6 +183,7 @@ class Trainer(ParallelWorkerBase):
                 triplet_exporter=self.triplet_exporter,
                 max_tasks=self.max_tasks,
                 worker_id=worker_id,
+                batch_size=self.batch_size,
             )
             loop.init_worker(worker_id)
             if is_async:

--- a/tests/test_litagent.py
+++ b/tests/test_litagent.py
@@ -1,0 +1,43 @@
+import pytest
+
+from agentlightning.litagent import LitAgent
+
+
+def test_rollout_batch_defaults_to_single_rollout():
+    class DummyAgent(LitAgent):
+        def __init__(self):
+            super().__init__()
+            self.calls = []
+
+        def training_rollout(self, task, rollout_id, resources):
+            self.calls.append((task, rollout_id))
+            return 1.0
+
+    agent = DummyAgent()
+    results = agent.training_rollout_batch([1, 2], ["r1", "r2"], [{}, {}])
+    assert results == [1.0, 1.0]
+    assert agent.calls == [(1, "r1"), (2, "r2")]
+
+    val_results = agent.validation_rollout_batch([3], ["r3"], [{}])
+    assert val_results == [1.0]
+    assert agent.calls == [(1, "r1"), (2, "r2"), (3, "r3")]
+
+
+@pytest.mark.asyncio
+async def test_rollout_batch_async_defaults_to_single_rollout():
+    class DummyAsyncAgent(LitAgent):
+        def __init__(self):
+            super().__init__()
+            self.calls = []
+
+        async def training_rollout_async(self, task, rollout_id, resources):
+            self.calls.append((task, rollout_id))
+            return 1.0
+
+    agent = DummyAsyncAgent()
+    results = await agent.training_rollout_batch_async([1, 2], ["r1", "r2"], [{}, {}])
+    assert results == [1.0, 1.0]
+
+    val_results = await agent.validation_rollout_batch_async([3], ["r3"], [{}])
+    assert val_results == [1.0]
+    assert agent.calls == [(1, "r1"), (2, "r2"), (3, "r3")]


### PR DESCRIPTION
## Summary
- allow `training_rollout_batch`/`validation_rollout_batch` APIs to receive per-task resource lists
- add `batch_size` to `AgentRunner` and propagate through `Trainer` for batched polling
- test batch rollouts with resource lists

## Testing
- `pre-commit run --files agentlightning/litagent.py agentlightning/runner.py agentlightning/trainer.py tests/test_litagent.py`
- `pytest tests/test_litagent.py tests/test_client.py`


------
https://chatgpt.com/codex/tasks/task_e_689db4c153ec832ea2983ab0885c7f75