### PR TITLE
Ensure blank line after copyright header

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .[dev]
+      - name: Check Python headers
+        run: |
+          python scripts/check_python_headers.py
       - name: Run Black
         run: |
           black --check --diff --line-length=120 .

--- a/agentlightning/__init__.py
+++ b/agentlightning/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 __version__ = "0.1.2"
 
 from .client import AgentLightningClient, DevTaskLoader

--- a/agentlightning/cli/agentops_server.py
+++ b/agentlightning/cli/agentops_server.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import time
 from agentlightning.instrumentation.agentops import AgentOpsServerManager
 

--- a/agentlightning/cli/vllm.py
+++ b/agentlightning/cli/vllm.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 from typing import List
 
 from vllm.entrypoints.cli.main import main

--- a/agentlightning/client.py
+++ b/agentlightning/client.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import asyncio
 import logging
 import time

--- a/agentlightning/config.py
+++ b/agentlightning/config.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 """
 This file is not carefully reviewed.
 It might contain unintentional bugs and issues.

--- a/agentlightning/instrumentation/__init__.py
+++ b/agentlightning/instrumentation/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import warnings
 
 AGENTOPS_INSTALLED = False

--- a/agentlightning/instrumentation/agentops.py
+++ b/agentlightning/instrumentation/agentops.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import logging
 import multiprocessing
 import signal

--- a/agentlightning/instrumentation/agentops_langchain.py
+++ b/agentlightning/instrumentation/agentops_langchain.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 from typing import Dict, Any
 from agentops.integration.callbacks.langchain import LangchainCallbackHandler
 from agentops import instrumentation

--- a/agentlightning/instrumentation/litellm.py
+++ b/agentlightning/instrumentation/litellm.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 from typing import Optional, Any
 
 from litellm.integrations.opentelemetry import OpenTelemetry

--- a/agentlightning/instrumentation/verl_chat_scheduler.py
+++ b/agentlightning/instrumentation/verl_chat_scheduler.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 # type: ignore
 
 # https://github.com/volcengine/verl/blob/bd94bd61fe4193e56f2845dc794004afbef7f818/examples/ppo_trainer/naive_chat_scheduler.py

--- a/agentlightning/instrumentation/vllm.py
+++ b/agentlightning/instrumentation/vllm.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 from __future__ import annotations
 
 import warnings

--- a/agentlightning/litagent.py
+++ b/agentlightning/litagent.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 from __future__ import annotations
 
 import logging

--- a/agentlightning/logging.py
+++ b/agentlightning/logging.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import logging
 
 

--- a/agentlightning/reward.py
+++ b/agentlightning/reward.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import asyncio
 import inspect
 import warnings

--- a/agentlightning/runner.py
+++ b/agentlightning/runner.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import asyncio
 import json
 import logging

--- a/agentlightning/server.py
+++ b/agentlightning/server.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import asyncio
 import logging
 import time

--- a/agentlightning/tracer/__init__.py
+++ b/agentlightning/tracer/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 from .base import BaseTracer
 from .agentops import AgentOpsTracer
 from .triplet import TripletExporter

--- a/agentlightning/tracer/agentops.py
+++ b/agentlightning/tracer/agentops.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 from __future__ import annotations
 
 import logging

--- a/agentlightning/tracer/base.py
+++ b/agentlightning/tracer/base.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 from contextlib import contextmanager
 from typing import Iterator, List, Optional, Callable, Any, Awaitable
 

--- a/agentlightning/tracer/http.py
+++ b/agentlightning/tracer/http.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 from contextlib import contextmanager
 from typing import Iterator, List, Optional, Any, Dict, Callable, Awaitable
 import logging

--- a/agentlightning/tracer/triplet.py
+++ b/agentlightning/tracer/triplet.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import json
 import re
 from enum import Enum

--- a/agentlightning/trainer.py
+++ b/agentlightning/trainer.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import asyncio
 import logging
 import multiprocessing

--- a/agentlightning/types.py
+++ b/agentlightning/types.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 from typing import Any, Dict, List, Optional, Union, Literal, Annotated
 
 from pydantic import BaseModel, Field, Discriminator

--- a/agentlightning/verl/__init__.py
+++ b/agentlightning/verl/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 from .trainer import *
 from .daemon import *
 from .dataset import *

--- a/agentlightning/verl/__main__.py
+++ b/agentlightning/verl/__main__.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 from .entrypoint import main
 
 if __name__ == "__main__":

--- a/agentlightning/verl/async_server.py
+++ b/agentlightning/verl/async_server.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import ray
 from copy import deepcopy
 

--- a/agentlightning/verl/daemon.py
+++ b/agentlightning/verl/daemon.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import asyncio
 import json
 import random

--- a/agentlightning/verl/dataset.py
+++ b/agentlightning/verl/dataset.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import torch
 from verl.utils.dataset.rl_dataset import RLHFDataset
 

--- a/agentlightning/verl/entrypoint.py
+++ b/agentlightning/verl/entrypoint.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import hydra
 import ray
 

--- a/agentlightning/verl/trainer.py
+++ b/agentlightning/verl/trainer.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import random
 from contextlib import contextmanager
 from copy import deepcopy

--- a/examples/apo/apo.py
+++ b/examples/apo/apo.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import asyncio
 
 from agentlightning.server import AgentLightningServer

--- a/examples/apo/apo_client.py
+++ b/examples/apo/apo_client.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import dotenv
 import os
 import random

--- a/examples/calc_x/calc_agent.py
+++ b/examples/calc_x/calc_agent.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import math
 import os
 import string

--- a/examples/calc_x/calc_agent_dev.py
+++ b/examples/calc_x/calc_agent_dev.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import os
 from agentlightning import Trainer, DevTaskLoader, LLM
 from calc_agent import CalcAgent

--- a/examples/calc_x/tests/test_agentops.py
+++ b/examples/calc_x/tests/test_agentops.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import agentops
 from agentlightning.reward import reward
 from agentops.sdk.decorators import operation

--- a/examples/calc_x/tests/test_mcp_calculator.py
+++ b/examples/calc_x/tests/test_mcp_calculator.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import os
 import asyncio
 import json

--- a/examples/rag/rag_agent.py
+++ b/examples/rag/rag_agent.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 from __future__ import annotations
 
 import os

--- a/examples/rag/utils.py
+++ b/examples/rag/utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import json
 import pickle
 import re

--- a/examples/rag/wiki_retriever_mcp/wiki_retriever_mcp.py
+++ b/examples/rag/wiki_retriever_mcp/wiki_retriever_mcp.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import faiss
 from sentence_transformers import SentenceTransformer
 import pickle

--- a/examples/spider/spider_eval/convert_dataset.py
+++ b/examples/spider/spider_eval/convert_dataset.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import os
 
 import pandas as pd

--- a/examples/spider/spider_eval/evaluation.py
+++ b/examples/spider/spider_eval/evaluation.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 # type: ignore
 # The evaluation code is from https://github.com/taoyds/test-suite-sql-eval
 

--- a/examples/spider/spider_eval/exec_eval.py
+++ b/examples/spider/spider_eval/exec_eval.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 # type: ignore
 # The evaluation code is from https://github.com/taoyds/test-suite-sql-eval
 

--- a/examples/spider/spider_eval/parse.py
+++ b/examples/spider/spider_eval/parse.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 # type: ignore
 # The evaluation code is from https://github.com/taoyds/test-suite-sql-eval
 

--- a/examples/spider/spider_eval/process_sql.py
+++ b/examples/spider/spider_eval/process_sql.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 # type: ignore
 # The evaluation code is from https://github.com/taoyds/test-suite-sql-eval
 

--- a/examples/spider/sql_agent.py
+++ b/examples/spider/sql_agent.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 """
 Adapted from https://python.langchain.com/docs/tutorials/sql_qa/
 as well as https://langchain-ai.github.io/langgraph/tutorials/sql-agent/

--- a/scripts/check_python_headers.py
+++ b/scripts/check_python_headers.py
@@ -28,9 +28,7 @@ def iter_python_files() -> list[Path]:
         check=True,
         cwd=REPO_ROOT,
     )
-    return [
-        REPO_ROOT / line.strip() for line in result.stdout.splitlines() if line.strip()
-    ]
+    return [REPO_ROOT / line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
 def main() -> int:
@@ -64,14 +62,10 @@ def main() -> int:
         )
 
     if missing_blank_line:
-        print(
-            "The following Python files are missing a blank line after the copyright header:"
-        )
+        print("The following Python files are missing a blank line after the copyright header:")
         for path in missing_blank_line:
             print(f" - {path}")
-        print(
-            "Ensure there is an empty line separating the header from the rest of the file."
-        )
+        print("Ensure there is an empty line separating the header from the rest of the file.")
 
     if missing_header or missing_blank_line:
         return 1

--- a/scripts/check_python_headers.py
+++ b/scripts/check_python_headers.py
@@ -1,0 +1,78 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Utility script to ensure Python files include the required copyright header."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REQUIRED_HEADER = "# Copyright (c) Microsoft. All rights reserved."
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def iter_python_files() -> list[Path]:
+    """Return a list of tracked Python files respecting .gitignore rules."""
+    result = subprocess.run(
+        [
+            "git",
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "*.py",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=REPO_ROOT,
+    )
+    return [REPO_ROOT / line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def main() -> int:
+    missing_header: list[str] = []
+    missing_blank_line: list[str] = []
+
+    for file_path in iter_python_files():
+        try:
+            with file_path.open("r", encoding="utf-8") as file:
+                first_line = file.readline().rstrip("\r\n")
+                second_line = file.readline()
+        except OSError as exc:
+            print(f"Failed to read {file_path}: {exc}", file=sys.stderr)
+            return 1
+
+        if first_line != REQUIRED_HEADER:
+            missing_header.append(str(file_path.relative_to(REPO_ROOT)))
+            continue
+
+        if second_line == "" or second_line.strip():
+            missing_blank_line.append(str(file_path.relative_to(REPO_ROOT)))
+
+    if missing_header:
+        print("The following Python files are missing the required copyright header:")
+        for path in missing_header:
+            print(f" - {path}")
+        print(
+            "Run the appropriate script or add the header manually:",
+            f"\n{REQUIRED_HEADER}",
+        )
+
+    if missing_blank_line:
+        print(
+            "The following Python files are missing a blank line after the copyright header:"
+        )
+        for path in missing_blank_line:
+            print(f" - {path}")
+        print("Ensure there is an empty line separating the header from the rest of the file.")
+
+    if missing_header or missing_blank_line:
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_python_headers.py
+++ b/scripts/check_python_headers.py
@@ -28,7 +28,9 @@ def iter_python_files() -> list[Path]:
         check=True,
         cwd=REPO_ROOT,
     )
-    return [REPO_ROOT / line.strip() for line in result.stdout.splitlines() if line.strip()]
+    return [
+        REPO_ROOT / line.strip() for line in result.stdout.splitlines() if line.strip()
+    ]
 
 
 def main() -> int:
@@ -48,7 +50,8 @@ def main() -> int:
             missing_header.append(str(file_path.relative_to(REPO_ROOT)))
             continue
 
-        if second_line == "" or second_line.strip():
+        # Second line should be either an EOF or a blank line
+        if second_line and second_line.strip():
             missing_blank_line.append(str(file_path.relative_to(REPO_ROOT)))
 
     if missing_header:
@@ -66,7 +69,9 @@ def main() -> int:
         )
         for path in missing_blank_line:
             print(f" - {path}")
-        print("Ensure there is an empty line separating the header from the rest of the file.")
+        print(
+            "Ensure there is an empty line separating the header from the rest of the file."
+        )
 
     if missing_header or missing_blank_line:
         return 1

--- a/scripts/validate_example_wandb.py
+++ b/scripts/validate_example_wandb.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import wandb
 import sys
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import asyncio
 import time
 from typing import Any, Dict, AsyncGenerator

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 """
 This file is not carefully reviewed.
 It is to ensure the *somewhat* correctness of the code in agentlightning/config.py.

--- a/tests/test_litagent_hooks.py
+++ b/tests/test_litagent_hooks.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 import pytest
 from contextlib import contextmanager
 

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 """
 Integration tests for various agent frameworks with AgentLightning.
 

--- a/tests/test_tracer_http.py
+++ b/tests/test_tracer_http.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 #!/usr/bin/env python3
 """
 Functional tests for HttpTracer with real HTTP requests.


### PR DESCRIPTION
## Summary
- add the Microsoft copyright header to every tracked Python module with a separating blank line
- add a reusable script that checks for the header (and blank line) while respecting .gitignore
- run the header validation script in the lint workflow

## Testing
- python scripts/check_python_headers.py

------
https://chatgpt.com/codex/tasks/task_e_68ccbf22cdd4832e8f30411dc2964dfc