### PR TITLE
Add DeepWerewolf community project listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Join our [Discord community](https://discord.gg/RYk7CdvDR7) to connect with othe
 - 7/26/2025 [We discovered an approach to train any AI agent with RL, with (almost) zero code changes.](https://www.reddit.com/r/LocalLLaMA/comments/1m9m670/we_discovered_an_approach_to_train_any_ai_agent/) Reddit.
 - 6/6/2025 [Agent Lightning - Microsoft Research](https://www.microsoft.com/en-us/research/project/agent-lightning/) Project page.
 
+## ⚡ Community Projects
+
+- [DeepWerewolf](https://github.com/af-74413592/DeepWerewolf) — A case study of agent RL training for the Chinese Werewolf game built with AgentScope and Agent Lightning.
+
 ## ⚡ Installation
 
 First, let's get your environment set up. We'll be using `/path/to/agentlightning` to refer to the directory containing this README file.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,10 @@ Agent Lightning is the absolute trainer to light up AI agents.
 - 7/26/2025 [We discovered an approach to train any AI agent with RL, with (almost) zero code changes.](https://www.reddit.com/r/LocalLLaMA/comments/1m9m670/we_discovered_an_approach_to_train_any_ai_agent/) Reddit.
 - 6/6/2025 [Agent Lightning - Microsoft Research](https://www.microsoft.com/en-us/research/project/agent-lightning/) Project page.
 
+## Community Projects
+
+- [DeepWerewolf](https://github.com/af-74413592/DeepWerewolf) — A case study of agent RL training for the Chinese Werewolf game built with AgentScope and Agent Lightning.
+
 ## Citation
 
 If you find Agent Lightning useful in your research or projects, please cite our paper:


### PR DESCRIPTION
## Summary
- add the DeepWerewolf case study to the README under a new Community Projects section
- list the DeepWerewolf project on the docs landing page for community efforts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d62787db9c832e81f021f73775dde1