### PR TITLE
Fix HTTP tracer tests

### DIFF
--- a/tests/test_tracer_http.py
+++ b/tests/test_tracer_http.py
@@ -17,8 +17,10 @@ from agentlightning.tracer.http import HttpTracer
 
 def sync_http_function():
     """A simple synchronous function that makes HTTP requests."""
-    response = requests.get("https://httpbingo.org/get")
-    response2 = requests.post("https://httpbingo.org/post", json={"test": "data"})
+    s = requests.Session()
+    s.headers.update({"Accept-Encoding": "gzip, deflate"})  # no zstd
+    response = s.get("https://httpbingo.org/get")
+    response2 = s.post("https://httpbingo.org/post", json={"test": "data"})
     return {
         "get_status": response.status_code,
         "post_status": response2.status_code,


### PR DESCRIPTION
This PR should fix the following issue:

```
self = <aiohttp.http_parser.DeflateBuffer object at 0x7f6ab0d99ea0>
chunk = b"(\xb5/\xfd\x00H\xfd\t\x00&S>%\x00\xcbX\x07\xbc\x83C\xc8c\xc2,\xba\xdcC\x14\x87\xe3\xdfQ\x93\xa7z\x87\x0e\xf9C\xbf\x0...2\xe22\xd4p\x04\xed\x18*a;B\xe0\xca*\xb9^`\xaa\x95s\x06A\xc6T\x1d\xb2S\xf9\x83\xe1\x18\xbf\x92\xc3S\x9c4\x8a)\xb4`\x0f"
size = 328

    def feed_data(self, chunk: bytes, size: int) -> None:
        if not size:
            return
    
        self.size += size
        self.out.total_compressed_bytes = self.size
    
        # RFC1950
        # bits 0..3 = CM = 0b1000 = 8 = "deflate"
        # bits 4..7 = CINFO = 1..7 = windows size.
        if (
            not self._started_decoding
            and self.encoding == "deflate"
            and chunk[0] & 0xF != 8
        ):
            # Change the decoder to decompress incorrectly compressed data
            # Actually we should issue a warning about non-RFC-compliant data.
            self.decompressor = ZLibDecompressor(
                encoding=self.encoding, suppress_deflate_header=True
            )
    
        try:
            chunk = self.decompressor.decompress_sync(chunk)
        except Exception:
>           raise ContentEncodingError(
                "Can not decode content-encoding: %s" % self.encoding
            )
E           aiohttp.http_exceptions.ContentEncodingError: 400, message:
E             Can not decode content-encoding: zstd

/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/aiohttp/http_parser.py:1020: ContentEncodingError

The above exception was the direct cause of the following exception:

    @pytest.mark.flaky(reruns=3, reruns_delay=2)
    @pytest.mark.asyncio
    async def test_normal_mode_async_requests():
        """Test HttpTracer in normal mode with asynchronous requests."""
        tracer = HttpTracer(include_headers=True, include_body=True, subprocess_mode=False)
    
>       result = await tracer.trace_run_async(async_http_function)

tests/test_tracer_http.py:128: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
agentlightning/tracer/http.py:264: in trace_run_async
    return await super().trace_run_async(func, *args, **kwargs)
agentlightning/tracer/base.py:127: in trace_run_async
    return await func(*args, **kwargs)
tests/test_tracer_http.py:34: in async_http_function
    get_data = await response.json()
/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/aiohttp/client_reqrep.py:753: in json
    await self.read()
/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/aiohttp/client_reqrep.py:695: in read
    self._body = await self.content.read()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <StreamReader e=ClientPayloadError('400, message:\n  Can not decode content-encoding: zstd')>
n = -1

    async def read(self, n: int = -1) -> bytes:
        if self._exception is not None:
>           raise self._exception
E           aiohttp.client_exceptions.ClientPayloadError: 400, message:
E             Can not decode content-encoding: zstd

/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/aiohttp/streams.py:400: ClientPayloadError
```