### PR TITLE
Show pytest durations in workflows

### DIFF
--- a/.github/workflows/tests-full.yml
+++ b/.github/workflows/tests-full.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           set -ex
           . .venv/bin/activate
-          pytest -v tests
+          pytest -v --durations=0 tests
         env:
           PYTEST_ADDOPTS: "--color=yes"
           OPENAI_BASE_URL: ${{ secrets.OPENAI_API_BASE }}  # We will use BASE_URL instead of API_BASE in pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,6 +121,6 @@ jobs:
           compression-level: 0
       - name: Run tests
         run: |
-          pytest -v tests
+          pytest -v --durations=0 tests
         env:
           PYTEST_ADDOPTS: "--color=yes"


### PR DESCRIPTION
## Summary
- update the CPU and GPU test workflows to run pytest with --durations=0 so test timing details are emitted

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6a103078c832ea700f8c598db06e2