### PR TITLE
Add AgentFlow to community project listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Join our [Discord community](https://discord.gg/RYk7CdvDR7) to connect with othe
 ## ⚡ Community Projects
 
 - [DeepWerewolf](https://github.com/af-74413592/DeepWerewolf) — A case study of agent RL training for the Chinese Werewolf game built with AgentScope and Agent Lightning.
+- [AgentFlow](https://agentflow.stanford.edu/) — A modular multi-agent framework that combines planner, executor, verifier, and generator agents with the Flow-GRPO algorithm to tackle long-horizon, sparse-reward tasks.
 
 ## ⚡ Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ Agent Lightning is the absolute trainer to light up AI agents.
 ## Community Projects
 
 - [DeepWerewolf](https://github.com/af-74413592/DeepWerewolf) — A case study of agent RL training for the Chinese Werewolf game built with AgentScope and Agent Lightning.
+- [AgentFlow](https://agentflow.stanford.edu/) — A modular multi-agent framework that combines planner, executor, verifier, and generator agents with the Flow-GRPO algorithm to tackle long-horizon, sparse-reward tasks.
 
 ## Citation
 


### PR DESCRIPTION
## Summary
- add AgentFlow to the community projects section in the README
- mirror the AgentFlow listing in the documentation home page

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e918ec1648832ea9ce4b4c956e19bd