### PR TITLE
Expose adapter, store, and trainer utilities

### DIFF
--- a/agentlightning/adapter/__init__.py
+++ b/agentlightning/adapter/__init__.py
@@ -1,6 +1,23 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-from .base import Adapter, TraceAdapter
+from .base import Adapter, OtelTraceAdapter, TraceAdapter
+from .messages import (
+    OpenAIMessages,
+    TraceMessagesAdapter,
+    convert_to_openai_messages,
+    group_genai_dict,
+)
 from .triplet import BaseTraceTripletAdapter, LlmProxyTripletAdapter, TraceTripletAdapter
 
-__all__ = ["TraceAdapter", "Adapter", "BaseTraceTripletAdapter", "TraceTripletAdapter", "LlmProxyTripletAdapter"]
+__all__ = [
+    "Adapter",
+    "TraceAdapter",
+    "OtelTraceAdapter",
+    "BaseTraceTripletAdapter",
+    "TraceTripletAdapter",
+    "LlmProxyTripletAdapter",
+    "TraceMessagesAdapter",
+    "OpenAIMessages",
+    "group_genai_dict",
+    "convert_to_openai_messages",
+]

--- a/agentlightning/instrumentation/__init__.py
+++ b/agentlightning/instrumentation/__init__.py
@@ -109,3 +109,13 @@ def uninstrument_all():
             warnings.warn("agentops_langchain is installed but uninstrument_agentops_langchain could not be imported.")
     else:
         warnings.warn("Agentops-langchain integration is not installed. It's therefore not uninstrumented.")
+
+
+__all__ = [
+    "AGENTOPS_INSTALLED",
+    "AGENTOPS_LANGCHAIN_INSTALLED",
+    "LITELLM_INSTALLED",
+    "VLLM_INSTALLED",
+    "instrument_all",
+    "uninstrument_all",
+]

--- a/agentlightning/store/__init__.py
+++ b/agentlightning/store/__init__.py
@@ -1,1 +1,24 @@
 # Copyright (c) Microsoft. All rights reserved.
+
+"""Convenience imports for the Lightning store implementations."""
+
+from .base import UNSET, LightningStore, Unset, is_finished, is_queuing, is_running
+from .client_server import LightningStoreClient, LightningStoreServer
+from .memory import InMemoryLightningStore
+from .threading import LightningStoreThreaded
+from .utils import healthcheck, propagate_status
+
+__all__ = [
+    "LightningStore",
+    "LightningStoreClient",
+    "LightningStoreServer",
+    "LightningStoreThreaded",
+    "InMemoryLightningStore",
+    "UNSET",
+    "Unset",
+    "is_queuing",
+    "is_running",
+    "is_finished",
+    "healthcheck",
+    "propagate_status",
+]

--- a/agentlightning/trainer/__init__.py
+++ b/agentlightning/trainer/__init__.py
@@ -1,5 +1,19 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+from .init_utils import (
+    build_component,
+    instantiate_component,
+    instantiate_from_spec,
+    load_class,
+)
+from .registry import ExecutionStrategyRegistry
 from .trainer import Trainer
 
-__all__ = ["Trainer"]
+__all__ = [
+    "Trainer",
+    "ExecutionStrategyRegistry",
+    "load_class",
+    "instantiate_component",
+    "instantiate_from_spec",
+    "build_component",
+]

--- a/docs/reference/core.md
+++ b/docs/reference/core.md
@@ -26,6 +26,16 @@
     options:
       show_source: true
 
+## Adapters and Stores
+
+::: agentlightning.adapter
+    options:
+      show_source: true
+
+::: agentlightning.store
+    options:
+      show_source: true
+
 ## Server Side
 
 ::: agentlightning.server


### PR DESCRIPTION
## Summary
- expose adapter conversion helpers alongside existing triplet adapters
- surface lightning store primitives and trainer initialization utilities via package exports
- document adapter and store modules in the core reference guide

## Testing
- python - <<'PY'
from agentlightning.adapter import (
    Adapter,
    TraceAdapter,
    OtelTraceAdapter,
    TraceMessagesAdapter,
    OpenAIMessages,
)
from agentlightning.store import (
    LightningStore,
    LightningStoreClient,
    LightningStoreServer,
    LightningStoreThreaded,
    InMemoryLightningStore,
    UNSET,
    is_queuing,
    healthcheck,
)
from agentlightning.trainer import (
    Trainer,
    ExecutionStrategyRegistry,
    load_class,
    instantiate_component,
    instantiate_from_spec,
    build_component,
)
from agentlightning.instrumentation import instrument_all, uninstrument_all

print("Imports successful")
PY

------
https://chatgpt.com/codex/tasks/task_e_68e8e93a38e0832e90c5bf9efcbb870c