### PR TITLE
[WIP] Upgrade vLLM to 0.11.0

### DIFF
--- a/scripts/setup_latest_gpu.sh
+++ b/scripts/setup_latest_gpu.sh
@@ -7,7 +7,7 @@ pip install --no-cache-dir packaging ninja numpy pandas ipython ipykernel gdown 
 pip install --no-cache-dir torch==2.8.0 torchvision==0.23.0 --index-url https://download.pytorch.org/whl/cu128
 pip install --no-cache-dir flash-attn --no-build-isolation
 # This must match pytorch version.
-pip install --no-cache-dir vllm==0.10.2
+pip install --no-cache-dir vllm==0.11.0
 # Latest VERL release version.
 pip install --no-cache-dir verl
 


### PR DESCRIPTION
It's not working with verl 0.5.0.

```bash
ray.exceptions.RayTaskError(ModuleNotFoundError): ray::WorkerDict.actor_rollout_init_model() (pid=10928, ip=10.1.1.104, actor_id=3b846a02a80aa8b92c91fcfb01000000, repr=<verl.single_controller.ray.base.WorkerDict object at 0x78f9a5c11e50>)
  File "/usr/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
           ^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/vss/_work/agent-lightning/agent-lightning/.venv/lib/python3.12/site-packages/verl/single_controller/ray/base.py", line 705, in func
    return getattr(self.worker_dict[key], name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/vss/_work/agent-lightning/agent-lightning/.venv/lib/python3.12/site-packages/verl/single_controller/base/decorator.py", line 514, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/vss/_work/agent-lightning/agent-lightning/.venv/lib/python3.12/site-packages/verl/workers/fsdp_workers.py", line 626, in init_model
    self.rollout, self.rollout_sharding_manager = self._build_rollout(
                                                  ^^^^^^^^^^^^^^^^^^^^
  File "/mnt/vss/_work/agent-lightning/agent-lightning/.venv/lib/python3.12/site-packages/verl/workers/fsdp_workers.py", line 1647, in _build_rollout
    rollout, rollout_sharding_manager = super()._build_rollout(trust_remote_code)
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/vss/_work/agent-lightning/agent-lightning/.venv/lib/python3.12/site-packages/verl/workers/fsdp_workers.py", line 481, in _build_rollout
    from verl.workers.rollout.vllm_rollout import vLLMRollout
  File "/mnt/vss/_work/agent-lightning/agent-lightning/.venv/lib/python3.12/site-packages/verl/workers/rollout/vllm_rollout/__init__.py", line 17, in <module>
    from .vllm_rollout_spmd import vLLMAsyncRollout, vLLMRollout  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/vss/_work/agent-lightning/agent-lightning/.venv/lib/python3.12/site-packages/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py", line 50, in <module>
    from vllm.model_executor.sampling_metadata import SamplingMetadata
ModuleNotFoundError: No module named 'vllm.model_executor.sampling_metadata'
```