### PR TITLE
Allow plain sequences to satisfy Dataset protocol

### DIFF
--- a/agentlightning/types/core.py
+++ b/agentlightning/types/core.py
@@ -12,6 +12,7 @@ from typing import (
     Literal,
     Optional,
     Protocol,
+    SupportsIndex,
     TypeVar,
     Union,
     cast,
@@ -264,7 +265,7 @@ class Dataset(Protocol, Generic[T_co]):
     You don't have to inherit from this class; you can use a simple list if you want to.
     """
 
-    def __getitem__(self, index: int) -> T_co: ...
+    def __getitem__(self, index: SupportsIndex, /) -> T_co: ...
 
     def __len__(self) -> int: ...
 

--- a/examples/unsloth/math_agent.py
+++ b/examples/unsloth/math_agent.py
@@ -19,7 +19,7 @@ python math_agent.py
 import json
 import os
 import re
-from typing import Any, Optional, TypedDict, cast
+from typing import Any, Optional, TypedDict
 
 import numpy as np
 from agents import Agent, ModelSettings, OpenAIChatCompletionsModel, Runner
@@ -56,7 +56,7 @@ def _download_dataset() -> None:  # pyright: ignore[reportUnusedFunction]
     Downloads the first 64 samples from the dataset and saves them to data_gsmhard.jsonl.
     This function is provided as a utility to help set up the dataset for the first time.
     """
-    ds = load_dataset("reasoning-machines/gsm-hard", split="train")
+    ds = load_dataset("reasoning-machines/gsm-hard", split="train")  # pyright: ignore[reportUnknownVariableType]
     df = ds.to_list()  # type: ignore
     with open("data_gsmhard.jsonl", "w") as f:
         for i, row in enumerate(df):  # type: ignore
@@ -79,7 +79,7 @@ def load_math_dataset(limit: Optional[int] = None) -> Dataset[GsmProblem]:
         problems = [GsmProblem(**json.loads(line)) for line in f]
     if limit is not None:
         problems = problems[:limit]
-    return cast(Dataset[GsmProblem], problems)
+    return problems
 
 
 @rollout

--- a/tests/algorithm/test_decorator.py
+++ b/tests/algorithm/test_decorator.py
@@ -3,7 +3,7 @@
 """Test that @algo decorator preserves function executability."""
 
 import inspect
-from typing import Any, Optional, cast
+from typing import Any, Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -81,7 +81,7 @@ def test_algorithm_run_method():
     val_data = ["val1"]
 
     # Call run method
-    test_algo.run(cast(Dataset[Any], train_data), cast(Dataset[Any], val_data))
+    test_algo.run(train_data, val_data)
 
     # Verify execution
     assert test_algo.executed  # type: ignore
@@ -146,7 +146,7 @@ async def test_async_algorithm_run_method():
 
     # Run method should return an awaitable
     assert async_algo.is_async()
-    result = async_algo.run(cast(Dataset[Any], train_data), cast(Dataset[Any], val_data))
+    result = async_algo.run(train_data, val_data)
     assert inspect.iscoroutine(result)
 
     # Await the result
@@ -254,7 +254,7 @@ def test_algorithm_raises_error_on_unsupported_train_dataset():
 
     # Providing train_dataset should raise TypeError
     with pytest.raises(TypeError, match="train_dataset is provided but not supported"):
-        no_train_algo.run(train_dataset=cast(Dataset[Any], ["data"]), val_dataset=None)
+        no_train_algo.run(train_dataset=["data"], val_dataset=None)
 
 
 def test_algorithm_raises_error_on_unsupported_val_dataset():
@@ -267,7 +267,7 @@ def test_algorithm_raises_error_on_unsupported_val_dataset():
 
     # Providing val_dataset should raise TypeError
     with pytest.raises(TypeError, match="val_dataset is provided but not supported"):
-        no_val_algo.run(train_dataset=None, val_dataset=cast(Dataset[Any], ["data"]))
+        no_val_algo.run(train_dataset=None, val_dataset=["data"])
 
 
 def test_algorithm_with_all_injected_parameters():
@@ -306,7 +306,7 @@ def test_algorithm_with_all_injected_parameters():
     val_data = ["val"]
 
     # Run the algorithm
-    full_algo.run(cast(Dataset[Any], train_data), cast(Dataset[Any], val_data))
+    full_algo.run(train_data, val_data)
 
     # Verify all parameters were injected correctly
     assert full_algo.store == mock_store  # type: ignore
@@ -356,7 +356,7 @@ async def test_async_algorithm_with_injected_parameters():
     async_full_algo.set_store(mock_store)  # type: ignore
 
     train_data = ["async-train"]
-    await async_full_algo.run(cast(Dataset[Any], train_data))  # type: ignore
+    await async_full_algo.run(train_data)  # type: ignore
 
     assert async_full_algo.store == mock_store  # type: ignore
     assert async_full_algo.train == train_data  # type: ignore

--- a/tests/algorithm/test_mock.py
+++ b/tests/algorithm/test_mock.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from contextlib import suppress
 from dataclasses import dataclass
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List
 
 import pytest
 
@@ -13,7 +13,6 @@ from agentlightning.algorithm.mock import MockAlgorithm
 from agentlightning.store.memory import InMemoryLightningStore
 from agentlightning.types import (
     LLM,
-    Dataset,
     NamedResources,
     Resource,
     Span,
@@ -126,7 +125,7 @@ async def test_mock_algorithm_collects_rollout_logs(caplog: pytest.LogCaptureFix
 
     runner_task = asyncio.create_task(_mock_runner(store=store, expected=expected_rollouts, artifacts=artifacts))
     try:
-        await algorithm.run(train_dataset=cast(Dataset[Any], train_dataset))
+        await algorithm.run(train_dataset=train_dataset)
         await asyncio.wait_for(runner_task, timeout=2)
     finally:
         if not runner_task.done():


### PR DESCRIPTION
## Summary
- allow the Dataset protocol to accept any SupportsIndex-compatible index so plain lists satisfy the contract
- remove now-unnecessary Dataset casts across examples and tests

## Testing
- pyright agentlightning/types/core.py
- pyright examples/unsloth/math_agent.py
- pyright tests/algorithm/test_decorator.py
- pyright tests/algorithm/test_mock.py
- pytest tests/algorithm/test_decorator.py tests/algorithm/test_mock.py

------
https://chatgpt.com/codex/tasks/task_e_68edab86c054832eaa2d8089c9229e45