### PR TITLE
Preserve timeout status when spans arrive

### DIFF
--- a/agentlightning/store/memory.py
+++ b/agentlightning/store/memory.py
@@ -419,7 +419,7 @@ class InMemoryLightningStore(LightningStore):
 
         # Update attempt heartbeat
         current_attempt.last_heartbeat_time = time.time()
-        if current_attempt.status in ["preparing", "unresponsive", "timeout"]:
+        if current_attempt.status in ["preparing", "unresponsive"]:
             current_attempt.status = "running"
 
         # If the status has already timed out or failed, do not change it


### PR DESCRIPTION
## Summary
- keep in-memory store from flipping timed-out attempts back to running when a span arrives
- add a regression test ensuring spans leave timeout attempts and rollouts unchanged while still updating the heartbeat

## Testing
- pytest tests/store/test_memory.py -k timeout_attempt

------
https://chatgpt.com/codex/tasks/task_e_68f068a61a28832e9017ea9986df11e0