### PR TITLE
refactor: modernize agent docstrings

### DIFF
--- a/agentlightning/client.py
+++ b/agentlightning/client.py
@@ -1,6 +1,12 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-"""Legacy client for interacting with a legacy Agent Lightning server."""
+"""Utilities for interacting with legacy Agent Lightning servers.
+
+This module contains compatibility shims that speak the deprecated HTTP
+interface used by older Agent Lightning deployments. Modern code should prefer
+the store-based APIs exposed by `agentlightning.store`, but keeping these
+clients available makes it easier to migrate existing workflows incrementally.
+"""
 
 import asyncio
 import logging
@@ -18,13 +24,24 @@ logger = logging.getLogger(__name__)
 
 
 class AgentLightningClient:
-    """
-    Client for interacting with a version-aware Agent Lightning Server.
+    """Client wrapper for the legacy version-aware Agent Lightning server.
 
-    This client handles polling for tasks, fetching specific versions of resources
-    (like model configurations), and posting completed rollouts back to the server.
-    It provides both synchronous and asynchronous methods for these operations and
-    includes a cache for resources.
+    The client exposes synchronous and asynchronous helpers for polling tasks,
+    retrieving resource bundles, and submitting rollouts. It also maintains a
+    simple in-memory cache keyed by the server-provided resource identifier to
+    avoid redundant network requests.
+
+    !!! warning "Deprecated"
+        [`AgentLightningClient`][agentlightning.client.AgentLightningClient] is part of
+        the legacy client/server stack. New code should rely on the store-based APIs
+        implemented in `agentlightning.store`.
+
+    Attributes:
+        endpoint: Base URL of the Agent Lightning server.
+        poll_interval: Delay in seconds between polling attempts when no task is
+            available.
+        timeout: Timeout in seconds applied to HTTP requests.
+        task_count: Number of tasks claimed during the lifetime of this client.
     """
 
     _next_task_uri = "/task"
@@ -33,12 +50,12 @@ class AgentLightningClient:
     _report_rollout_uri = "/rollout"
 
     def __init__(self, endpoint: str, poll_interval: float = 5.0, timeout: float = 10.0):
-        """Initializes the AgentLightningClient.
+        """Initialize the client.
 
         Args:
-            endpoint: The root URL of the Agent Lightning server.
-            poll_interval: The interval in seconds to wait between polling for new tasks.
-            timeout: The timeout in seconds for HTTP requests.
+            endpoint: Root URL of the Agent Lightning server.
+            poll_interval: Seconds to wait between polling attempts.
+            timeout: Seconds before a request to the server is considered timed out.
         """
         warnings.warn(
             "AgentLightningClient is deprecated. Please use LightningStoreClient instead.", DeprecationWarning
@@ -51,13 +68,13 @@ class AgentLightningClient:
         self._default_headers = {"X-AgentLightning-Client": "true"}
 
     async def _request_json_async(self, url: str) -> Optional[Dict[str, Any]]:
-        """Makes an async GET request to the specified URL and returns the JSON response.
+        """Perform an asynchronous ``GET`` request and parse the JSON payload.
 
         Args:
-            url: The URL to request.
+            url: Fully qualified URL to query.
 
         Returns:
-            The JSON response as a dictionary or None if the request fails.
+            Parsed JSON body as a dictionary if the request succeeds; otherwise ``None``.
         """
         timeout = aiohttp.ClientTimeout(total=self.timeout)
         async with aiohttp.ClientSession(timeout=timeout) as session:
@@ -70,14 +87,14 @@ class AgentLightningClient:
                 return None
 
     async def _post_json_async(self, url: str, payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-        """Makes an async POST request with a JSON payload.
+        """Perform an asynchronous ``POST`` request with a JSON body.
 
         Args:
-            url: The URL to post to.
-            payload: The dictionary data to send as JSON.
+            url: Fully qualified URL that accepts the payload.
+            payload: Dictionary that will be serialized and sent as JSON.
 
         Returns:
-            The JSON response as a dictionary or None if the request fails.
+            Parsed JSON body as a dictionary if the request succeeds; otherwise ``None``.
         """
         timeout = aiohttp.ClientTimeout(total=self.timeout)
         async with aiohttp.ClientSession(timeout=timeout) as session:
@@ -90,10 +107,11 @@ class AgentLightningClient:
                 return None
 
     async def poll_next_task_async(self) -> Optional[Task]:
-        """Polls the server asynchronously for the next task until one is available.
+        """Poll the server asynchronously until a task becomes available.
 
         Returns:
-            A Task object containing the task details.
+            The next [`Task`][agentlightning.types.core.Task] exposed by the server,
+            or ``None`` if polling fails.
         """
         url = urllib.parse.urljoin(self.endpoint, self._next_task_uri)
         while True:
@@ -108,13 +126,15 @@ class AgentLightningClient:
             await asyncio.sleep(self.poll_interval)
 
     async def get_resources_by_id_async(self, resource_id: str) -> Optional[ResourcesUpdate]:
-        """Fetches a specific version of resources by its ID, using a cache.
+        """Fetch a specific resource bundle by identifier.
 
         Args:
-            resource_id: The ID of the resources to fetch, usually from a Task's metadata.
+            resource_id: Identifier sourced from the task metadata.
 
         Returns:
-            A ResourcesUpdate object containing the versioned resources, or None if not found.
+            Cached or freshly downloaded
+            [`ResourcesUpdate`][agentlightning.types.resources.ResourcesUpdate], or
+            ``None`` when the server returns an error.
         """
         if resource_id in self._resource_cache:
             logger.debug(f"Found resources '{resource_id}' in cache.")
@@ -130,10 +150,11 @@ class AgentLightningClient:
         return None
 
     async def get_latest_resources_async(self) -> Optional[ResourcesUpdate]:
-        """Fetches the latest available resources from the server.
+        """Fetch the most recent resource bundle advertised by the server.
 
         Returns:
-            A ResourcesUpdate object containing the latest resources.
+            [`ResourcesUpdate`][agentlightning.types.resources.ResourcesUpdate] for the
+            newest version, or ``None`` when unavailable.
         """
         url = urllib.parse.urljoin(self.endpoint, self._latest_resources_uri)
         response = await self._request_json_async(url)
@@ -145,26 +166,26 @@ class AgentLightningClient:
         return None
 
     async def post_rollout_async(self, rollout: RolloutLegacy) -> Optional[Dict[str, Any]]:
-        """Posts a completed rollout to the server asynchronously.
+        """Submit a completed rollout back to the server.
 
         Args:
-            rollout: A Rollout object containing the results of a task.
+            rollout: Legacy rollout payload produced by the executor.
 
         Returns:
-            The server's JSON response as a dictionary.
+            Parsed JSON response returned by the server, or ``None`` when the request fails.
         """
         url = urllib.parse.urljoin(self.endpoint, self._report_rollout_uri)
         payload = rollout.model_dump(mode="json")
         return await self._post_json_async(url, payload)
 
     def _request_json(self, url: str) -> Optional[Dict[str, Any]]:
-        """Makes a sync GET request to the specified URL and returns the JSON response.
+        """Perform a blocking ``GET`` request and parse the JSON payload.
 
         Args:
-            url: The URL to request.
+            url: Fully qualified URL to query.
 
         Returns:
-            The JSON response as a dictionary or None if the request fails.
+            Parsed JSON body as a dictionary if the request succeeds; otherwise ``None``.
         """
         try:
             response = requests.get(url, timeout=self.timeout, headers=self._default_headers)
@@ -175,14 +196,14 @@ class AgentLightningClient:
             return None
 
     def _post_json(self, url: str, payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-        """Makes a sync POST request with a JSON payload.
+        """Perform a blocking ``POST`` request with a JSON payload.
 
         Args:
-            url: The URL to post to.
-            payload: The dictionary data to send as JSON.
+            url: Fully qualified URL that accepts the payload.
+            payload: Dictionary that will be serialized and sent as JSON.
 
         Returns:
-            The JSON response as a dictionary or None if the request fails.
+            Parsed JSON body as a dictionary if the request succeeds; otherwise ``None``.
         """
         try:
             response = requests.post(url, json=payload, timeout=self.timeout, headers=self._default_headers)
@@ -193,10 +214,11 @@ class AgentLightningClient:
             return None
 
     def poll_next_task(self) -> Optional[Task]:
-        """Polls the server synchronously for the next task until one is available.
+        """Poll the server synchronously until a task becomes available.
 
         Returns:
-            A Task object containing the task details, including the required `resources_id`.
+            The next [`Task`][agentlightning.types.core.Task] available for execution, or
+            ``None`` if polling fails.
         """
         url = urllib.parse.urljoin(self.endpoint, self._next_task_uri)
         while True:
@@ -211,13 +233,15 @@ class AgentLightningClient:
             time.sleep(self.poll_interval)
 
     def get_resources_by_id(self, resource_id: str) -> Optional[ResourcesUpdate]:
-        """Fetches a specific version of resources by its ID synchronously, using a cache.
+        """Fetch a specific resource bundle by identifier.
 
         Args:
-            resource_id: The ID of the resources to fetch, usually from a Task's metadata.
+            resource_id: Identifier sourced from the task metadata.
 
         Returns:
-            A ResourcesUpdate object containing the versioned resources, or None if not found.
+            Cached or freshly downloaded
+            [`ResourcesUpdate`][agentlightning.types.resources.ResourcesUpdate], or
+            ``None`` when the server returns an error.
         """
         if resource_id in self._resource_cache:
             logger.debug(f"Found resources '{resource_id}' in cache.")
@@ -233,10 +257,11 @@ class AgentLightningClient:
         return None
 
     def get_latest_resources(self) -> Optional[ResourcesUpdate]:
-        """Fetches the latest available resources from the server synchronously.
+        """Fetch the most recent resource bundle advertised by the server.
 
         Returns:
-            A ResourcesUpdate object containing the latest resources.
+            [`ResourcesUpdate`][agentlightning.types.resources.ResourcesUpdate] for the
+            newest version, or ``None`` when unavailable.
         """
         url = urllib.parse.urljoin(self.endpoint, self._latest_resources_uri)
         response = self._request_json(url)
@@ -247,13 +272,13 @@ class AgentLightningClient:
         return None
 
     def post_rollout(self, rollout: RolloutLegacy) -> Optional[Dict[str, Any]]:
-        """Posts a completed rollout to the server synchronously.
+        """Submit a completed rollout back to the server.
 
         Args:
-            rollout: A Rollout object containing the results of a task.
+            rollout: Legacy rollout payload produced by the executor.
 
         Returns:
-            The server's JSON response as a dictionary.
+            Parsed JSON response returned by the server, or ``None`` when the request fails.
         """
         url = urllib.parse.urljoin(self.endpoint, self._report_rollout_uri)
         payload = rollout.model_dump(mode="json")
@@ -261,14 +286,15 @@ class AgentLightningClient:
 
 
 class DevTaskLoader(AgentLightningClient):
-    """A local task manager for development that provides sample tasks and resources.
+    """In-memory task loader used for development and integration tests.
 
-    This client mocks the server APIs by maintaining a local queue of tasks and resources
-    within the same process. It's designed for development, testing, and scenarios where
-    a full Agent Lightning server is not needed.
+    The loader mimics the behaviour of the legacy HTTP server by storing tasks and
+    resources locally. Polling methods simply iterate over the provided collection,
+    allowing rapid iteration without provisioning any external infrastructure.
 
-    The DevTaskLoader overrides the polling and resource fetching methods to return data
-    from local collections instead of making HTTP requests to a remote server.
+    !!! warning "Deprecated"
+        [`DevTaskLoader`][agentlightning.client.DevTaskLoader] is a compatibility shim.
+        Prefer [`Trainer.dev`][agentlightning.trainer.trainer.Trainer.dev] for new code.
     """
 
     def __init__(
@@ -277,12 +303,17 @@ class DevTaskLoader(AgentLightningClient):
         resources: Union[NamedResources, ResourcesUpdate],
         **kwargs: Any,
     ):
-        """Initializes the DevTaskLoader with pre-defined tasks and resources.
+        """Initialize the loader with predefined tasks and resources.
 
         Args:
-            tasks: Either a List of TaskInput objects or a List of Task objects.
-            resources: Either NamedResources or ResourcesUpdate object.
-            **kwargs: Additional arguments passed to the parent AgentLightningClient.
+            tasks: Sequence of task inputs or preconstructed tasks that will be served in
+                order.
+            resources: Static resources returned for any `resources_id` query.
+            **kwargs: Additional keyword arguments forwarded to the parent client.
+
+        Raises:
+            ValueError: If no tasks are provided or both [`Task`][agentlightning.types.core.Task]
+                and [`TaskInput`][agentlightning.types.core.TaskInput] instances are mixed.
         """
         warnings.warn("DevTaskLoader is deprecated. Please use Trainer.dev instead.", DeprecationWarning)
         super().__init__(endpoint="local://", **kwargs)
@@ -307,17 +338,18 @@ class DevTaskLoader(AgentLightningClient):
 
     @property
     def rollouts(self) -> List[RolloutLegacy]:
-        """Return rollouts that have been posted back to the loader."""
+        """Return the rollouts posted back to the loader during development runs."""
         return self._rollouts
 
     def poll_next_task(self) -> Optional[Task]:
-        """Returns the next task from the local queue.
+        """Return the next task from the local queue.
 
-        If tasks are TaskInput objects, assembles them into Task objects.
-        If tasks are already Task objects, returns them directly.
+        If [`TaskInput`][agentlightning.types.core.TaskInput] instances were provided,
+        they are converted into [`Task`][agentlightning.types.core.Task] objects on the
+        fly. Otherwise, the preconstructed tasks are returned in sequence.
 
         Returns:
-            The next Task object from the local task list.
+            Next task to execute.
         """
         if self._task_index >= len(self._tasks):
             self._task_index = 0

--- a/agentlightning/emitter/exception.py
+++ b/agentlightning/emitter/exception.py
@@ -13,7 +13,15 @@ logger = logging.getLogger(__name__)
 
 
 def emit_exception(exception: BaseException) -> None:
-    """Emit an exception as a span."""
+    """Record an exception with OpenTelemetry metadata.
+
+    Args:
+        exception: Raised exception instance to serialize into telemetry attributes.
+
+    !!! note
+        The helper validates its input. Non-exception values are ignored to prevent
+        noisy telemetry and indicate programming mistakes via the logger.
+    """
     if not isinstance(exception, BaseException):  # type: ignore
         logger.error(f"Expected an BaseException instance, got: {type(exception)}. Skip emit_exception.")
         return

--- a/agentlightning/emitter/message.py
+++ b/agentlightning/emitter/message.py
@@ -10,10 +10,14 @@ logger = logging.getLogger(__name__)
 
 
 def emit_message(message: str) -> None:
-    """Emit a string message as a span.
+    """Emit a textual message as an OpenTelemetry span.
 
-    OpenTelemetry has a dedicated design of logs by design, but we can also use spans to emit messages.
-    So that it can all be unified in the data store and analyzed together.
+    Args:
+        message: Human readable message to attach as a span attribute.
+
+    !!! note
+        OpenTelemetry distinguishes between logs and spans. Emitting the message as a
+        span keeps all Agent Lightning telemetry in a single data store for analysis.
     """
     if not isinstance(message, str):  # type: ignore
         logger.error(f"Message must be a string, got: {type(message)}. Skip emit_message.")

--- a/agentlightning/emitter/object.py
+++ b/agentlightning/emitter/object.py
@@ -12,7 +12,15 @@ logger = logging.getLogger(__name__)
 
 
 def emit_object(object: Any) -> None:
-    """Emit any object as a span. Make sure the object is JSON serializable."""
+    """Emit an object's serialized representation as an OpenTelemetry span.
+
+    Args:
+        object: Data structure to encode as JSON and attach to the span payload.
+
+    !!! note
+        The payload must be JSON serializable. Non-serializable objects are ignored and
+        an error is logged to aid debugging.
+    """
     try:
         serialized = json.dumps(object)
     except (TypeError, ValueError):

--- a/agentlightning/emitter/reward.py
+++ b/agentlightning/emitter/reward.py
@@ -2,6 +2,11 @@
 
 import asyncio
 import inspect
+
+"""Helpers for emitting reward spans and integrating with AgentOps telemetry."""
+
+import asyncio
+import inspect
 import json
 import logging
 import warnings
@@ -47,20 +52,26 @@ FnType = TypeVar("FnType", bound=Callable[..., Any])
 
 
 def _agentops_initialized() -> bool:
-    """Check if AgentOps is initialized in the current context."""
+    """Return ``True`` when the AgentOps client has been configured."""
     return agentops.get_client().initialized
 
 
 def reward(fn: FnType) -> FnType:
-    """
-    A decorator to wrap a function that computes rewards.
-    It will automatically handle the input and output of the function.
+    """Decorate a reward function so its outputs are tracked as spans.
+
+    The decorator integrates with AgentOps when it is available and falls back to
+    the built-in telemetry otherwise. Both synchronous and asynchronous functions
+    are supported transparently.
+
+    Args:
+        fn: Callable that produces a numeric reward.
+
+    Returns:
+        Wrapped callable that preserves the original signature.
     """
 
     def wrap_result(result: Optional[float]) -> RewardSpanData:
-        """
-        Wrap the result of the function in a dict.
-        """
+        """Normalize the reward value into the span payload format."""
         if result is None:
             return {"type": "reward", "value": None}
         if not isinstance(result, (float, int)):  # type: ignore
@@ -119,8 +130,18 @@ def reward(fn: FnType) -> FnType:
 
 
 def emit_reward(reward: float) -> ReadableSpan:
-    """
-    Record a new reward as a new span.
+    """Emit a reward value as an OpenTelemetry span.
+
+    Args:
+        reward: Numeric reward to record. Integers and booleans are converted to
+            floating point numbers for consistency.
+
+    Returns:
+        Readable span capturing the recorded reward.
+
+    Raises:
+        ValueError: If the provided reward cannot be interpreted as a float or the
+            resulting span is not a ``ReadableSpan`` instance.
     """
     logger.debug(f"Emitting reward: {reward}")
     if isinstance(reward, (int, bool)):
@@ -139,8 +160,13 @@ def emit_reward(reward: float) -> ReadableSpan:
 
 
 def get_reward_value(span: SpanLike) -> Optional[float]:
-    """
-    Get the reward value from a span.
+    """Extract the reward value from a span, if available.
+
+    Args:
+        span: Span object produced by AgentOps or Agent Lightning emitters.
+
+    Returns:
+        The reward encoded in the span or ``None`` when the span does not represent a reward.
     """
     for key in [
         "agentops.task.output",  # newer versions of agentops
@@ -178,35 +204,31 @@ def get_reward_value(span: SpanLike) -> Optional[float]:
 
 
 def is_reward_span(span: SpanLike) -> bool:
-    """
-    Check if a span is a reward span.
-    """
+    """Return ``True`` when the provided span encodes a reward value."""
     maybe_reward = get_reward_value(span)
     return maybe_reward is not None
 
 
 def find_reward_spans(spans: Sequence[SpanLike]) -> List[SpanLike]:
-    """
-    Find all reward spans in the given list of spans.
+    """Return all reward spans in the provided sequence.
 
     Args:
-        spans: A list of spans (either ReadableSpan or Span).
+        spans: Sequence containing `ReadableSpan` objects or mocked span-like values.
 
     Returns:
-        A list of spans whose name matches the reward span name.
+        List of spans that could be parsed as rewards.
     """
     return [span for span in spans if is_reward_span(span)]
 
 
 def find_final_reward(spans: Sequence[SpanLike]) -> Optional[float]:
-    """
-    Get the last reward value from a list of spans.
+    """Return the last reward value present in the provided spans.
 
     Args:
-        spans: A list of spans (either ReadableSpan or Span).
+        spans: Sequence containing `ReadableSpan` objects or mocked span-like values.
 
     Returns:
-        The reward value from the last reward span, or None if not found.
+        Reward value from the latest reward span, or ``None`` when none are found.
     """
     for span in reversed(spans):
         reward = get_reward_value(span)

--- a/agentlightning/emitter/utils.py
+++ b/agentlightning/emitter/utils.py
@@ -1,19 +1,19 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-"""Common utilities for the emitter module."""
+"""Utilities shared across emitter implementations."""
 
 import opentelemetry.trace as trace_api
 from opentelemetry.trace import get_tracer_provider
 
 
 def get_tracer() -> trace_api.Tracer:
-    """Return the tracer used for AgentLightning spans.
-
-    Raises:
-        RuntimeError: If the tracer is not initialized.
+    """Resolve the OpenTelemetry tracer configured for Agent Lightning.
 
     Returns:
-        The AgentLightning tracer instance.
+        OpenTelemetry tracer tagged with the ``agentlightning`` instrumentation name.
+
+    Raises:
+        RuntimeError: If OpenTelemetry was not initialized before calling this helper.
     """
     if hasattr(trace_api, "_TRACER_PROVIDER") and trace_api._TRACER_PROVIDER is None:  # type: ignore[attr-defined]
         raise RuntimeError("Tracer is not initialized. Cannot emit a meaningful span.")

--- a/agentlightning/litagent/decorator.py
+++ b/agentlightning/litagent/decorator.py
@@ -1,5 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+"""Convenience decorators for building lightweight `LitAgent` implementations."""
+
 from __future__ import annotations
 
 import functools
@@ -90,24 +92,25 @@ class FunctionalLitAgentFunc(Protocol[T_contra]):
 
 
 class FunctionalLitAgent(LitAgent[T]):
-    """A specialized LitAgent that wraps a function-based rollout that accepts
-    dynamically a task input and a configured resource (LLM / prompt template / ...).
+    """Adapter that turns plain rollout functions into [`LitAgent`][agentlightning.litagent.litagent.LitAgent] instances.
 
-    This class allows users to define agent behavior using a simple function
-    that takes task input and a resource, rather than implementing a full
-    LitAgent subclass.
+    The helper inspects the wrapped function to determine which resources to
+    inject, allowing both synchronous and asynchronous callables to participate
+    in the training loop without writing a dedicated subclass.
     """
 
     def __init__(self, rollout_func: FunctionalLitAgentFunc[T], *, strip_proxy: bool = True) -> None:
-        """
-        Initialize the FunctionalLitAgent with a functional rollout function.
+        """Initialize the wrapper around a rollout function.
 
         Args:
-            rollout_func: A function that defines the agent's behavior.
-                          Can be sync or async, and can optionally accept a Rollout parameter.
-                          The function signature determines which resources are injected (llm, prompt_template, etc.).
-            strip_proxy: Whether to strip the ProxyLLM resource into a LLM resource when the function accepts an llm parameter.
-                         Defaults to True.
+            rollout_func: Callable that implements the rollout. It may be synchronous
+                or asynchronous and can optionally receive a
+                [`Rollout`][agentlightning.types.core.Rollout] alongside resources such as
+                ``llm`` or ``prompt_template``.
+            strip_proxy: When ``True``, convert
+                [`ProxyLLM`][agentlightning.types.resources.ProxyLLM] inputs into
+                [`LLM`][agentlightning.types.resources.LLM] instances before calling the
+                rollout function. Defaults to ``True``.
         """
         super().__init__()
         self._rollout_func = rollout_func
@@ -138,12 +141,15 @@ class FunctionalLitAgent(LitAgent[T]):
         """Execute a synchronous rollout using the wrapped function.
 
         Args:
-            task: The task input data.
-            resources: Dictionary of named resources including LLMs.
-            rollout: The rollout object with metadata.
+            task: Task input data.
+            resources: Mapping of named resources available to the agent.
+            rollout: Rollout metadata provided by the runtime.
 
         Returns:
-            The result from the wrapped rollout function.
+            Result produced by the wrapped rollout function.
+
+        Raises:
+            RuntimeError: If the wrapped function is asynchronous.
         """
         if self._is_async:
             raise RuntimeError(f"{self._rollout_func} is asynchronous. Use rollout_async instead.")
@@ -155,12 +161,15 @@ class FunctionalLitAgent(LitAgent[T]):
         """Execute an asynchronous rollout using the wrapped function.
 
         Args:
-            task: The task input data.
-            resources: Dictionary of named resources including LLMs.
-            rollout: The rollout object with metadata.
+            task: Task input data.
+            resources: Mapping of named resources available to the agent.
+            rollout: Rollout metadata provided by the runtime.
 
         Returns:
-            The result from the wrapped rollout function.
+            Result produced by the wrapped rollout coroutine.
+
+        Raises:
+            RuntimeError: If the wrapped function is synchronous.
         """
         if not self._is_async:
             raise RuntimeError(f"{self._rollout_func} is synchronous. Use rollout instead.")
@@ -169,18 +178,14 @@ class FunctionalLitAgent(LitAgent[T]):
         return await self._rollout_func(task, **kwargs)  # type: ignore
 
     def _get_kwargs(self, resources: NamedResources, rollout: Rollout) -> Dict[str, Any]:
-        """Extract the kwargs needed for the rollout function based on its signature.
-
-        Dynamically builds the kwargs dictionary by inspecting the function signature and
-        including only the parameters the function accepts. This allows flexible function
-        signatures that can request any combination of: rollout, llm, and/or prompt_template.
+        """Prepare keyword arguments expected by the wrapped rollout function.
 
         Args:
-            resources: Dictionary of named resources available for the rollout.
-            rollout: The rollout object with metadata.
+            resources: Mapping of named resources available for the rollout.
+            rollout: Rollout metadata provided by the runtime.
 
         Returns:
-            A dictionary of kwargs to pass to the rollout function.
+            Dictionary of keyword arguments to forward to the rollout function.
         """
 
         kwargs: Dict[str, Any] = {}
@@ -194,19 +199,17 @@ class FunctionalLitAgent(LitAgent[T]):
         return kwargs
 
     def _get_llm_resource(self, resources: NamedResources, rollout: Rollout) -> LLM:
-        """Extract the first LLM resource from the resources dictionary.
-
-        Strip the ProxyLLM resource into a LLM resource if needed.
+        """Retrieve the first LLM resource from the available resources.
 
         Args:
-            resources: Dictionary of named resources.
-            rollout: The rollout object with metadata.
+            resources: Mapping of named resources.
+            rollout: Rollout metadata used when stripping proxy endpoints.
 
         Returns:
-            The first LLM resource found.
+            First [`LLM`][agentlightning.types.resources.LLM] resource encountered.
 
         Raises:
-            ValueError: If no LLM resource is found.
+            ValueError: If no LLM resource is present.
         """
         resource_found: LLM | None = None
         for name, resource in resources.items():
@@ -225,17 +228,17 @@ class FunctionalLitAgent(LitAgent[T]):
         return resource_found
 
     def _get_prompt_template_resource(self, resources: NamedResources, rollout: Rollout) -> PromptTemplate:
-        """Extract the first PromptTemplate resource from the resources dictionary.
+        """Retrieve the first prompt template resource from the available resources.
 
         Args:
-            resources: Dictionary of named resources.
-            rollout: The rollout object with metadata. Not used in this method.
+            resources: Mapping of named resources.
+            rollout: Rollout metadata (unused).
 
         Returns:
-            The first PromptTemplate resource found.
+            First [`PromptTemplate`][agentlightning.types.resources.PromptTemplate] resource encountered.
 
         Raises:
-            ValueError: If no PromptTemplate resource is found.
+            ValueError: If no prompt template resource is present.
         """
         resource_found: PromptTemplate | None = None
         for name, resource in resources.items():
@@ -253,21 +256,18 @@ class FunctionalLitAgent(LitAgent[T]):
         return resource_found
 
     def _strip_proxy_helper(self, proxy_llm: LLM, rollout: Rollout) -> LLM:
-        """Strip the ProxyLLM resource into a concrete LLM resource.
-
-        This method resolves ProxyLLM instances to their concrete LLM implementation
-        by attaching the attempted rollout context. This is only used when the function
-        signature accepts an 'llm' parameter and strip_proxy is True.
+        """Convert [`ProxyLLM`][agentlightning.types.resources.ProxyLLM] instances into concrete LLMs.
 
         Args:
-            proxy_llm: The LLM resource, which may be a ProxyLLM.
-            rollout: The rollout object with metadata.
+            proxy_llm: Candidate LLM resource.
+            rollout: Rollout metadata that provides rollout and attempt identifiers.
 
         Returns:
-            The concrete LLM resource.
+            [`LLM`][agentlightning.types.resources.LLM] with rollout context baked into the endpoint.
 
         Raises:
-            ValueError: If the rollout is not an AttemptedRollout (required for stripping ProxyLLM).
+            ValueError: If the rollout is not an
+                [`AttemptedRollout`][agentlightning.types.core.AttemptedRollout].
         """
 
         if not isinstance(proxy_llm, ProxyLLM):
@@ -293,41 +293,35 @@ def llm_rollout(*, strip_proxy: bool = True) -> Callable[[LlmRolloutFunc[T]], Fu
 def llm_rollout(
     func: LlmRolloutFunc[T] | None = None, *, strip_proxy: bool = True
 ) -> FunctionalLitAgent[T] | Callable[[LlmRolloutFunc[T]], FunctionalLitAgent[T]]:
-    """Create a FunctionalLitAgent from a function that takes (task, llm[, rollout]).
-
-    This decorator allows you to define an agent using a simple function
-    instead of creating a full LitAgent subclass. The returned FunctionalLitAgent
-    instance is callable, preserving the original function's behavior.
+    """Create a [`FunctionalLitAgent`][agentlightning.litagent.decorator.FunctionalLitAgent] for LLM-based rollouts.
 
     Args:
-        func: A function that defines the agent's behavior. Can be:
-              - sync: (task, llm) -> result
-              - sync with rollout: (task, llm, rollout) -> result
-              - async: async (task, llm) -> result
-              - async with rollout: async (task, llm, rollout) -> result
-        strip_proxy: Whether to strip the ProxyLLM resource into a LLM resource.
-                     Defaults to True.
+        func: Callable defining the agent's behaviour. Supported signatures include:
+
+            * ``(task, llm) -> result``
+            * ``(task, llm, rollout) -> result``
+            * ``async (task, llm) -> result``
+            * ``async (task, llm, rollout) -> result``
+
+        strip_proxy: When ``True``, convert proxy resources into concrete
+            [`LLM`][agentlightning.types.resources.LLM] instances before calling the
+            function. Defaults to ``True``.
 
     Returns:
-        A callable FunctionalLitAgent instance that preserves the original function's
-        type hints and behavior while providing all agent functionality.
+        [`FunctionalLitAgent`][agentlightning.litagent.decorator.FunctionalLitAgent] that
+        wraps the supplied function.
 
     Examples:
         ```python
         @llm_rollout
         def my_agent(task, llm):
-            # Agent logic here
-            return response
+            return llm.endpoint
 
         @llm_rollout(strip_proxy=False)
         def my_agent_no_strip(task, llm):
-            # Agent logic here
-            return response
+            return llm.model
 
-        # Function is still callable with original behavior
         result = my_agent(task, llm)
-
-        # Agent methods are also available
         result = my_agent.rollout(task, resources, rollout)
         ```
     """
@@ -345,19 +339,13 @@ def llm_rollout(
 
 
 def _validate_llm_rollout_func(func: Any) -> TypeGuard[LlmRolloutFunc[Any]]:
-    """Validate the function signature of a LLM rollout function.
-
-    Ensures the function follows the expected pattern for LLM-based rollouts:
-    - Must have at least 2 parameters
-    - First parameter must be named 'task'
-    - Must have a parameter named 'llm'
-    - Optionally can have a 'rollout' parameter
+    """Validate the function signature of an LLM rollout function.
 
     Args:
-        func: The function to validate.
+        func: Function to inspect.
 
     Returns:
-        True if the function signature is valid.
+        ``True`` when the signature matches the supported patterns.
 
     Raises:
         ValueError: If the function signature does not match the expected pattern.
@@ -385,36 +373,28 @@ def prompt_rollout() -> Callable[[PromptRolloutFunc[T]], FunctionalLitAgent[T]]:
 def prompt_rollout(
     func: PromptRolloutFunc[T] | None = None,
 ) -> FunctionalLitAgent[T] | Callable[[PromptRolloutFunc[T]], FunctionalLitAgent[T]]:
-    """Create a FunctionalLitAgent from a function that takes (task, prompt_template[, rollout]).
-
-    This decorator is designed for agents that work with tunable prompt templates. It enables
-    a workflow where algorithms manage and optimize the prompt template, while agents consume
-    the template to perform rollouts. This is particularly useful for prompt optimization scenarios.
+    """Create a [`FunctionalLitAgent`][agentlightning.litagent.decorator.FunctionalLitAgent] for prompt-based rollouts.
 
     Args:
-        func: A function that defines the agent's behavior. Can be:
-              - sync: (task, prompt_template) -> result
-              - sync with rollout: (task, prompt_template, rollout) -> result
-              - async: async (task, prompt_template) -> result
-              - async with rollout: async (task, prompt_template, rollout) -> result
+        func: Callable defining the agent's behaviour. Supported signatures include:
+
+            * ``(task, prompt_template) -> result``
+            * ``(task, prompt_template, rollout) -> result``
+            * ``async (task, prompt_template) -> result``
+            * ``async (task, prompt_template, rollout) -> result``
 
     Returns:
-        A callable FunctionalLitAgent instance that preserves the original function's
-        type hints and behavior while providing all agent functionality.
+        [`FunctionalLitAgent`][agentlightning.litagent.decorator.FunctionalLitAgent] that
+        wraps the supplied function.
 
     Examples:
         ```python
         @prompt_rollout
         def my_agent(task, prompt_template):
-            # Use the prompt template to generate a response
             messages = prompt_template.format(task=task.input)
-            # ... perform rollout with the formatted prompt
-            return response
+            return messages
 
-        # Function is still callable with original behavior
         result = my_agent(task, prompt_template)
-
-        # Agent methods are also available
         result = my_agent.rollout(task, resources, rollout)
         ```
     """
@@ -432,17 +412,11 @@ def prompt_rollout(
 def _validate_prompt_rollout_func(func: Any) -> TypeGuard[PromptRolloutFunc[Any]]:
     """Validate the function signature of a prompt rollout function.
 
-    Ensures the function follows the expected pattern for prompt-template-based rollouts:
-    - Must have at least 2 parameters
-    - First parameter must be named 'task'
-    - Must have a parameter named 'prompt_template'
-    - Optionally can have a 'rollout' parameter
-
     Args:
-        func: The function to validate.
+        func: Function to inspect.
 
     Returns:
-        True if the function signature is valid.
+        ``True`` when the signature matches the supported patterns.
 
     Raises:
         ValueError: If the function signature does not match the expected pattern.
@@ -460,50 +434,33 @@ def _validate_prompt_rollout_func(func: Any) -> TypeGuard[PromptRolloutFunc[Any]
 
 
 def rollout(func: Union[LlmRolloutFunc[T], PromptRolloutFunc[T], Callable[..., Any]]) -> FunctionalLitAgent[T]:
-    """Create a LitAgent from a function, automatically detecting the appropriate type.
-
-    This function inspects the provided callable and creates the appropriate
-    agent type based on its signature. It supports both LLM-based and prompt-template-based
-    agents. The returned agent instance is callable, preserving the original function's
-    behavior and type hints.
+    """Create a [`FunctionalLitAgent`][agentlightning.litagent.decorator.FunctionalLitAgent] from an arbitrary rollout function.
 
     Args:
-        func: A function that defines the agent's behavior. Supported signatures:
-              - (task, llm[, rollout]) for LLM-based agents
-              - (task, prompt_template[, rollout]) for prompt-template-based agents
+        func: Callable that implements the rollout. Supported signatures include
+            those listed in [`llm_rollout`][agentlightning.litagent.decorator.llm_rollout]
+            and [`prompt_rollout`][agentlightning.litagent.decorator.prompt_rollout].
 
     Returns:
-        A callable FunctionalLitAgent instance that preserves the original function's
-        type hints and behavior while providing all agent functionality.
+        [`FunctionalLitAgent`][agentlightning.litagent.decorator.FunctionalLitAgent] that
+        wraps the supplied function.
 
     Examples:
         ```python
-        # LLM-based agent
         @rollout
         def my_llm_agent(task, llm):
-            client = OpenAI(base_url=llm.endpoint)
-            response = client.chat.completions.create(
-                model=llm.model,
-                messages=[{"role": "user", "content": task.input}],
-            )
-            return response
+            return llm.model
 
-        # Prompt-template-based agent
         @rollout
         def my_prompt_agent(task, prompt_template):
-            messages = prompt_template.format(task=task.input)
-            # ... perform rollout with the formatted prompt
-            return response
+            return prompt_template.format(task=task.input)
 
-        # Function is still callable with original behavior
         result = my_llm_agent(task, llm)
-
-        # Agent methods are also available
         result = my_llm_agent.rollout(task, resources, rollout)
         ```
 
     Raises:
-        NotImplementedError: If the function signature doesn't match any known patterns.
+        NotImplementedError: If the function signature does not match a supported pattern.
     """
     # Check if it matches the LLM rollout API pattern
     sig = inspect.signature(func)

--- a/agentlightning/litagent/litagent.py
+++ b/agentlightning/litagent/litagent.py
@@ -1,5 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+"""Base abstractions for building agents that plug into Agent Lightning."""
+
 from __future__ import annotations
 
 import inspect
@@ -26,32 +28,37 @@ __all__ = [
 
 
 def is_v0_1_rollout_api(func: Callable[..., Any]) -> bool:
-    """Check if the rollout API is v0.1.
-    Inspect the function signature to see if it has a rollout_id parameter.
+    """Return ``True`` when the rollout function uses the deprecated v0.1 signature.
+
+    The helper inspects the callable's signature to detect whether a ``rollout_id``
+    parameter is present, which indicates the legacy API.
 
     Args:
-        func: The function to check.
+        func: Function to analyze.
+
+    Returns:
+        ``True`` if the callable exposes a ``rollout_id`` parameter.
     """
     return "rollout_id" in inspect.signature(func).parameters
 
 
 class LitAgent(Generic[T]):
-    """Base class for the training and validation logic of an agent.
+    """Base class for implementing agent rollouts.
 
-    Developers should subclass this class and implement the rollout methods
-    to define the agent's behavior for a single task. The agent's logic
-    is completely decoupled from the server communication and training
-    infrastructure.
+    Subclasses override the rollout methods to process tasks while the trainer and
+    runner infrastructure manages orchestration, tracing, and persistence.
     """
 
     def __init__(self, *, trained_agents: Optional[str] = None) -> None:  # FIXME: str | None won't work for cli
-        """
-        Initialize the LitAgent.
+        """Initialize the agent instance.
 
         Args:
-            trained_agents: Optional string representing the trained agents.
-                            This can be used to track which agents have been trained by this instance.
-                            Deprecated. Configure `agent_match` in adapter instead.
+            trained_agents: Optional identifier used by legacy tooling to mark trained
+                agents.
+
+        !!! warning "Deprecated"
+            The `trained_agents` flag is deprecated. Configure `agent_match` in the adapter
+            layer instead.
         """
         if trained_agents is not None:
             warnings.warn(
@@ -65,13 +72,7 @@ class LitAgent(Generic[T]):
         self._runner_ref: weakref.ReferenceType[Runner[T]] | None = None
 
     def is_async(self) -> bool:
-        """
-        Check if the agent implements asynchronous rollout methods.
-        Override this property for customized async detection logic.
-
-        Returns:
-            True if the agent has custom async rollout methods, False otherwise.
-        """
+        """Return ``True`` when the agent overrides any asynchronous rollout methods."""
         return (
             (
                 hasattr(self, "training_rollout_async")
@@ -85,21 +86,15 @@ class LitAgent(Generic[T]):
         )
 
     def set_trainer(self, trainer: Trainer) -> None:
-        """
-        Set the trainer for this agent.
+        """Attach the trainer responsible for orchestration.
 
         Args:
-            trainer: The Trainer instance that will handle training and validation.
+            trainer: [`Trainer`][agentlightning.trainer.trainer.Trainer] that manages the agent.
         """
         self._trainer_ref = weakref.ref(trainer)
 
     def get_trainer(self) -> Trainer:
-        """
-        Get the trainer for this agent.
-
-        Returns:
-            The Trainer instance associated with this agent.
-        """
+        """Return the trainer associated with this agent."""
         if self._trainer_ref is None:
             raise ValueError("Trainer has not been set for this agent.")
         trainer = self._trainer_ref()
@@ -109,16 +104,11 @@ class LitAgent(Generic[T]):
 
     @property
     def trainer(self) -> Trainer:
-        """Convenient shortcut of self.get_trainer()."""
+        """Return the trainer associated with this agent."""
         return self.get_trainer()
 
     def get_tracer(self) -> Tracer:
-        """
-        Get the tracer for this agent.
-
-        Returns:
-            The Tracer instance associated with this agent.
-        """
+        """Return the tracer configured for this agent."""
         if hasattr(self.runner, "tracer"):
             return self.runner.tracer  # type: ignore
         else:
@@ -126,25 +116,19 @@ class LitAgent(Generic[T]):
 
     @property
     def tracer(self) -> Tracer:
-        """Convenient shortcut of self.get_tracer()."""
+        """Return the tracer configured for this agent."""
         return self.get_tracer()
 
     def set_runner(self, runner: Runner[T]) -> None:
-        """
-        Set the runner for this agent.
+        """Attach the runner responsible for executing rollouts.
 
         Args:
-            runner: The runner instance that will handle the execution of rollouts.
+            runner: [`Runner`][agentlightning.runner.base.Runner] coordinating execution.
         """
         self._runner_ref = weakref.ref(runner)
 
     def get_runner(self) -> Runner[T]:
-        """
-        Get the runner for this agent.
-
-        Returns:
-            The runner instance associated with this agent.
-        """
+        """Return the runner responsible for executing rollouts."""
         if self._runner_ref is None:
             raise ValueError("Runner has not been set for this agent.")
         runner = self._runner_ref()
@@ -154,159 +138,108 @@ class LitAgent(Generic[T]):
 
     @property
     def runner(self) -> Runner[T]:
-        """Convenient shortcut of self.get_runner()."""
+        """Return the runner responsible for executing rollouts."""
         return self.get_runner()
 
     def on_rollout_start(self, task: Task, runner: Runner[T], tracer: Tracer) -> None:
-        """Hook called immediately before a rollout begins.
+        """Hook invoked immediately before a rollout begins.
 
         Args:
-            task: The `Task` object that will be processed.
-            runner: The [`Runner`][agentlightning.Runner] managing the rollout.
-            tracer: The [`Tracer`][agentlightning.Tracer] instance associated with the runner.
+            task: [`Task`][agentlightning.types.core.Task] that will be processed.
+            runner: [`Runner`][agentlightning.runner.base.Runner] managing the rollout.
+            tracer: [`Tracer`][agentlightning.tracer.base.Tracer] associated with the runner.
 
-        Deprecated:
-            In favor of `on_rollout_start` in the [`Hook`][agentlightning.Hook] interface.
+        !!! warning "Deprecated"
+            Override [`Hook.on_rollout_start`][agentlightning.types.core.Hook.on_rollout_start]
+            instead of this method when extending agents.
 
-        Subclasses can override this method to implement custom logic such as
-        logging, metric collection, or resource setup. By default, this is a
-        no-op.
+        Subclasses can override this method to implement custom logic such as logging,
+        metric collection, or resource setup. The default implementation is a no-op.
         """
 
     def on_rollout_end(self, task: Task, rollout: Rollout, runner: Runner[T], tracer: Tracer) -> None:
-        """Hook called after a rollout completes.
-
-        Deprecated in favor of `on_rollout_end` in the `Hook` interface.
+        """Hook invoked after a rollout completes.
 
         Args:
-            task: The `Task` object that was processed.
-            rollout: The resulting [`Rollout`][agentlightning.Rollout] object.
-            runner: The [`Runner`][agentlightning.Runner] managing the rollout.
-            tracer: The [`Tracer`][agentlightning.Tracer] instance associated with the runner.
+            task: [`Task`][agentlightning.types.core.Task] that was processed.
+            rollout: Resulting [`Rollout`][agentlightning.types.core.Rollout].
+            runner: [`Runner`][agentlightning.runner.base.Runner] managing the rollout.
+            tracer: [`Tracer`][agentlightning.tracer.base.Tracer] associated with the runner.
 
-        Subclasses can override this method for cleanup or additional
-        logging. By default, this is a no-op.
+        !!! warning "Deprecated"
+            Override [`Hook.on_rollout_end`][agentlightning.types.core.Hook.on_rollout_end]
+            instead of this method when extending agents.
+
+        Subclasses can override this method for cleanup or additional logging. The default
+        implementation is a no-op.
         """
 
     def rollout(self, task: T, resources: NamedResources, rollout: Rollout) -> RolloutRawResult:
-        """Main entry point for executing a rollout.
-
-        This method determines whether to call the synchronous or
-        asynchronous rollout method based on the agent's implementation.
-
-        If you don't wish to implement both training rollout and validation
-        rollout separately, you can just implement `rollout` which will work for both.
+        """Execute a rollout synchronously.
 
         Args:
-            task: The task object received from the server, containing the
-                  input data and metadata.
-            resources: A dictionary of named resources (e.g., LLMs, prompt
-                       templates) for the agent to use.
-            rollout: The full rollout object, please avoid from directly modifying it.
-                     Most agents should only use `task` and `resources`. Use `rollout`
-                     only if you need to access metadata like `rollout_id`.
+            task: Task payload provided by the scheduler.
+            resources: Mapping of named resources (for example LLMs or prompt templates).
+            rollout: Rollout metadata. Avoid mutating this object directly unless a
+                subclass needs to override defaults.
 
         Returns:
-            The result of the rollout, which can be one of:
-            - None. The tracing should be handled by the agent runner.
-            - A float representing the final reward.
-            - A list of `Triplet` objects for detailed, step-by-step feedback.
-            - A list of `ReadableSpan` objects for OpenTelemetry tracing.
-            - A list of dictionaries for any trace spans.
-            - A complete `Rollout` object for full control over reporting.
+            One of the following values:
+
+            * ``None`` when tracing is handled by the runner.
+            * ``float`` representing the final reward.
+            * ``List[Triplet]`` providing step-by-step feedback.
+            * ``List[ReadableSpan]`` with OpenTelemetry spans.
+            * ``List[dict[str, Any]]`` representing serialized spans.
+            * [`Rollout`][agentlightning.types.core.Rollout] for complete manual control.
         """
         raise NotImplementedError("Agents must implement the `rollout` method.")
 
     async def rollout_async(self, task: T, resources: NamedResources, rollout: Rollout) -> RolloutRawResult:
-        """Asynchronous version of the main rollout method.
-
-        This method determines whether to call the synchronous or
-        asynchronous rollout method based on the agent's implementation.
+        """Execute a rollout asynchronously.
 
         Args:
-            task: The task object received from the server, containing the
-                  input data and metadata.
-            resources: A dictionary of named resources (e.g., LLMs, prompt
-                       templates) for the agent to use.
-            rollout: The full rollout object, please avoid from directly modifying it.
-                     Most agents should only use `task` and `resources`. Use `rollout`
-                     only if you need to access metadata like `rollout_id`.
+            task: Task payload provided by the scheduler.
+            resources: Mapping of named resources (for example LLMs or prompt templates).
+            rollout: Rollout metadata. Avoid mutating this object directly unless a
+                subclass needs to override defaults.
 
         Returns:
-            The result of the rollout, which can be one of:
-            - None. The tracing should be handled by the agent runner.
-            - A float representing the final reward.
-            - A list of `Triplet` objects for detailed, step-by-step feedback.
-            - A list of `ReadableSpan` objects for OpenTelemetry tracing.
-            - A list of dictionaries for any trace spans.
-            - A complete `Rollout` object for full control over reporting.
+            Same possible return values as
+            [`rollout`][agentlightning.litagent.litagent.LitAgent.rollout].
         """
         raise NotImplementedError("Agents must implement the `rollout_async` method for async operations.")
 
     def training_rollout(self, task: T, resources: NamedResources, rollout: Rollout) -> RolloutRawResult:
-        """Defines the agent's behavior for a single training task.
+        """Process a single training task synchronously.
 
-        This method should contain the logic for how the agent processes an
-        input, uses the provided resources (like LLMs or prompts), and
-        produces a result.
-
-        Args:
-            task: The task object received from the server, containing the
-                  input data and metadata.
-            resources: A dictionary of named resources (e.g., LLMs, prompt
-                       templates) for the agent to use.
-            rollout: The full rollout object, please avoid from directly modifying it.
+        By default, this method delegates to
+        [`rollout`][agentlightning.litagent.litagent.LitAgent.rollout].
         """
         return self.rollout(task, resources, rollout)
 
     def validation_rollout(self, task: T, resources: NamedResources, rollout: Rollout) -> RolloutRawResult:
-        """Defines the agent's behavior for a single validation task.
+        """Process a single validation task synchronously.
 
-        By default, this method redirects to `training_rollout`. Override it
-        if the agent should behave differently during validation.
-
-        Args:
-            task: The task object received from the server, containing the
-                  input data and metadata.
-            resources: A dictionary of named resources for the agent to use.
-            rollout: The full rollout object, avoid from modifying it.
-
-        Returns:
-            The result of the validation rollout. See `rollout` for
-            possible return types.
+        Override this method when validation should differ from training. The default
+        implementation delegates to
+        [`training_rollout`][agentlightning.litagent.litagent.LitAgent.training_rollout].
         """
         return self.rollout(task, resources, rollout)
 
     async def training_rollout_async(self, task: T, resources: NamedResources, rollout: Rollout) -> RolloutRawResult:
-        """Asynchronous version of `training_rollout`.
+        """Process a single training task asynchronously.
 
-        This method should be implemented by agents that perform asynchronous
-        operations (e.g., non-blocking I/O, concurrent API calls).
-
-        Args:
-            task: The task object received from the server.
-            resources: A dictionary of named resources for the agent to use.
-            rollout: The full rollout object, avoid from modifying it.
-
-        Returns:
-            The result of the asynchronous training rollout. See `rollout` for
-            possible return types.
+        By default, this method delegates to
+        [`rollout_async`][agentlightning.litagent.litagent.LitAgent.rollout_async].
         """
         return await self.rollout_async(task, resources, rollout)
 
     async def validation_rollout_async(self, task: T, resources: NamedResources, rollout: Rollout) -> RolloutRawResult:
-        """Asynchronous version of `validation_rollout`.
+        """Process a single validation task asynchronously.
 
-        By default, this method redirects to `training_rollout_async`.
-        Override it for different asynchronous validation behavior.
-
-        Args:
-            task: The task object received from the server.
-            resources: A dictionary of named resources for the agent to use.
-            rollout: The full rollout object, avoid from modifying it.
-
-        Returns:
-            The result of the asynchronous validation rollout. See `rollout` for
-            possible return types.
+        Override this method when validation should differ from training. The default
+        implementation delegates to
+        [`training_rollout_async`][agentlightning.litagent.litagent.LitAgent.training_rollout_async].
         """
         return await self.rollout_async(task, resources, rollout)

--- a/agentlightning/server.py
+++ b/agentlightning/server.py
@@ -1,6 +1,11 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-"""Legacy server for the Agent Lightning framework. Deprecated in favor of agentlightning.store."""
+"""Legacy HTTP server compatible with the original Agent Lightning protocol.
+
+The implementation in this module predates the modern store-powered runtime and
+is kept for backwards compatibility with older deployments. New applications
+should migrate to the store architecture where possible.
+"""
 
 from __future__ import annotations
 
@@ -29,9 +34,11 @@ logger = logging.getLogger(__name__)
 
 
 class ServerDataStore:
-    """
-    A centralized, thread-safe, async, in-memory data store for the server's state.
-    This holds the task queue, versioned resources, and completed rollouts.
+    """Async-safe container for in-memory server state.
+
+    The store tracks queued tasks, claimed tasks, uploaded rollouts, and the
+    currently published resources. All interactions are guarded by asyncio locks
+    so that the FastAPI handlers can safely run in parallel.
     """
 
     def __init__(self):
@@ -54,8 +61,18 @@ class ServerDataStore:
         resources_id: str | None = None,
         metadata: Dict[str, Any] | None = None,
     ) -> str:
-        """
-        Adds a new task to the queue with specific metadata and returns its unique ID.
+        """Enqueue a new task and return the generated rollout identifier.
+
+        Args:
+            sample: Payload that describes the task input.
+            mode: Phase in which the sample should be executed (`"train"`, `"val"`, or
+                `"test"`).
+            resources_id: Identifier of a resource bundle that the executor should
+                load before running the task.
+            metadata: Optional metadata forwarded to the executor.
+
+        Returns:
+            Unique rollout identifier assigned to the task.
         """
         rollout_id = f"rollout-{uuid.uuid4()}"
         task = Task(
@@ -72,9 +89,11 @@ class ServerDataStore:
         return rollout_id
 
     async def get_next_task(self) -> Optional[Task]:
-        """
-        Retrieves the next task from the queue without blocking.
-        Returns None if the queue is empty.
+        """Retrieve the next task from the queue without blocking.
+
+        Returns:
+            Next [`Task`][agentlightning.types.core.Task] ready to execute, or ``None``
+            when the queue is empty.
         """
         try:
             async with self._results_lock:
@@ -95,8 +114,10 @@ class ServerDataStore:
             return None
 
     async def update_resources(self, update: ResourcesUpdate):
-        """
-        Safely stores a new version of named resources and sets it as the latest.
+        """Persist a new resource bundle and mark it as the latest version.
+
+        Args:
+            update: Resource payload received from a client.
         """
         # TODO: evict old resources if necessary.
         async with self._resources_lock:
@@ -105,8 +126,14 @@ class ServerDataStore:
             logger.info(f"Resources updated. New version '{update.resources_id}' is now latest.")
 
     async def get_resources_by_id(self, resources_id: str) -> Optional[ResourcesUpdate]:
-        """
-        Safely retrieves a specific version of named resources by its ID.
+        """Retrieve a specific resource bundle by identifier.
+
+        Args:
+            resources_id: Identifier that was previously published to the store.
+
+        Returns:
+            Matching [`ResourcesUpdate`][agentlightning.types.resources.ResourcesUpdate]
+            instance, or ``None`` when the identifier is unknown.
         """
         async with self._resources_lock:
             resources = self._resource_versions.get(resources_id)
@@ -115,16 +142,16 @@ class ServerDataStore:
             return None
 
     async def get_latest_resources(self) -> Optional[ResourcesUpdate]:
-        """
-        Safely retrieves the latest version of named resources.
-        """
+        """Return the most recent resource bundle, if one exists."""
         if self._latest_resources_id:
             return await self.get_resources_by_id(self._latest_resources_id)
         return None
 
     async def store_rollout(self, rollout: RolloutLegacy):
-        """
-        Safely stores a completed rollout from a client.
+        """Persist a completed rollout for later inspection.
+
+        Args:
+            rollout: Rollout returned by a client.
         """
         async with self._results_lock:
             self._processing_tasks.pop(rollout.rollout_id, None)
@@ -132,27 +159,31 @@ class ServerDataStore:
             logger.info(f"Rollout received and stored: {rollout.rollout_id}")
 
     async def retrieve_rollout(self, rollout_id: str) -> Optional[RolloutLegacy]:
-        """
-        Safely retrieves a single rollout by its ID, removing it from the store.
+        """Retrieve and remove a stored rollout by identifier.
+
+        Args:
+            rollout_id: Identifier of the rollout to fetch.
+
+        Returns:
+            Stored [`RolloutLegacy`][agentlightning.types.core.RolloutLegacy], or ``None``
+            when the identifier is unknown.
         """
         async with self._results_lock:
             return self._completed_rollouts.pop(rollout_id, None)
 
     async def retrieve_completed_rollouts(self) -> List[RolloutLegacy]:
-        """
-        Retrieves all completed rollouts and clears the store.
-        """
+        """Return all completed rollouts and clear the internal buffer."""
         async with self._results_lock:
             rollouts = list(self._completed_rollouts.values())
             self._completed_rollouts.clear()
             return rollouts
 
     def get_processing_tasks(self) -> Dict[str, Task]:
-        """Returns a copy of currently processing tasks for timeout checking."""
+        """Return a copy of currently processing tasks for timeout checking."""
         return self._processing_tasks.copy()
 
     async def requeue_task(self, task: Task):
-        """Requeues a task that has timed out and removes it from processing."""
+        """Requeue a task that timed out while being processed."""
         logger.warning(f"Requeuing task {task.rollout_id} after timeout (attempt {task.num_claims})")
         async with self._results_lock:
             # Remove from processing tasks
@@ -161,21 +192,26 @@ class ServerDataStore:
 
 
 class AgentLightningServer:
-    """
-    The main SDK class for developers to control the Agent Lightning Server.
+    """High-level controller for the legacy Agent Lightning FastAPI server.
 
-    This class manages the server lifecycle, task queueing, resources updates,
-    and retrieval of results, providing a simple interface for the optimization logic.
+    The controller orchestrates server start-up, task queueing, resource updates,
+    and retrieval of client rollouts. It is primarily used by existing systems that
+    still rely on the HTTP-based workflow.
+
+    !!! warning "Deprecated"
+        [`AgentLightningServer`][agentlightning.server.AgentLightningServer] is part of
+        the legacy client/server stack. Prefer the store-based runtime for new
+        integrations.
     """
 
     def __init__(self, host: str = "127.0.0.1", port: int = 8000, task_timeout_seconds: float = 300.0):
-        """
-        Initializes the server controller.
+        """Initialize the controller.
 
         Args:
-            host: The host to bind the server to.
-            port: The port to bind the server to.
-            task_timeout_seconds: Time in seconds after which a claimed task is considered stale and requeued.
+            host: Hostname or IP address to bind the HTTP server to.
+            port: TCP port exposed by the server.
+            task_timeout_seconds: Seconds before a claimed task is considered stale and
+                re-queued.
         """
         warnings.warn(
             "AgentLightningServer is deprecated. Please use LightningStoreServer instead.", DeprecationWarning
@@ -200,9 +236,7 @@ class AgentLightningServer:
     # --- ADDED: Lifespan context manager ---
     @asynccontextmanager
     async def _lifespan(self, app: FastAPI):
-        """
-        Manages server startup and shutdown. This runs inside the server's event loop.
-        """
+        """Manage server start-up and shutdown within the event loop."""
         logger.info("Server is starting up...")
         self.loop = asyncio.get_running_loop()
         self._store = ServerDataStore()  # Initialize data store here
@@ -216,9 +250,7 @@ class AgentLightningServer:
         self.loop = None
 
     async def _check_and_requeue_stale_tasks(self):
-        """
-        Check for stale tasks and requeue them. Called reactively during get_next_task.
-        """
+        """Check for stale tasks and requeue them when they exceed the timeout."""
         current_time = time.time()
         # Ensure store is initialized before checking
         if not self._store:
@@ -233,11 +265,11 @@ class AgentLightningServer:
                 )
 
     def _setup_routes(self):
-        """Setup FastAPI routes."""
+        """Configure the FastAPI routes that make up the legacy HTTP API."""
 
         @self._app.get("/task", response_model=TaskIfAny)
         async def next_task() -> TaskIfAny:  # type: ignore
-            """Endpoint for clients to poll for the next available task."""
+            """Provide the next available task to a client."""
             await self._check_and_requeue_stale_tasks()
 
             if not self._store:
@@ -253,7 +285,7 @@ class AgentLightningServer:
 
         @self._app.get("/resources/latest", response_model=ResourcesUpdate)
         async def fetch_latest_resources() -> ResourcesUpdate:  # type: ignore
-            """Endpoint for clients to poll for the latest available resources."""
+            """Return the most recent resource bundle published to the server."""
             if not self._store:
                 raise HTTPException(status_code=503, detail="Server not fully initialized.")
             resources_update = await self._store.get_latest_resources()
@@ -266,7 +298,7 @@ class AgentLightningServer:
         async def fetch_resources_by_id(  # type: ignore
             resource_id: str = Path(..., description="The unique identifier for the resource version.")
         ) -> ResourcesUpdate:
-            """Endpoint for clients to fetch a specific version of resources."""
+            """Return a specific version of resources by identifier."""
             if not self._store:
                 raise HTTPException(status_code=503, detail="Server not fully initialized.")
             resources_update = await self._store.get_resources_by_id(resource_id)
@@ -277,7 +309,7 @@ class AgentLightningServer:
 
         @self._app.post("/rollout", response_model=GenericResponse)
         async def post_rollout(payload: RolloutLegacy) -> GenericResponse:  # type: ignore
-            """Endpoint for clients to report a completed rollout."""
+            """Persist the rollout reported by a client."""
             if not self._store:
                 raise HTTPException(status_code=503, detail="Server not fully initialized.")
             await self._store.store_rollout(payload)
@@ -287,13 +319,13 @@ class AgentLightningServer:
             )
 
     async def start(self):
-        """Starts the FastAPI server in the background."""
+        """Start the FastAPI server in the background."""
         logger.info(f"Starting server at {self.endpoint}")
         asyncio.create_task(self._uvicorn_server.serve())
         await asyncio.sleep(1)  # Allow time for server to start up.
 
     async def stop(self):
-        """Gracefully stops the running FastAPI server."""
+        """Stop the FastAPI server and wait for a graceful shutdown."""
         if self._uvicorn_server.started:
             logger.info("Stopping server...")
             self._uvicorn_server.should_exit = True
@@ -301,10 +333,7 @@ class AgentLightningServer:
             logger.info("Server stopped.")
 
     async def run_forever(self):
-        """
-        Runs the server indefinitely until stopped.
-        This is useful when async start and stop methods do not work.
-        """
+        """Run the server indefinitely until `stop()` is invoked."""
         await self._uvicorn_server.serve()
 
     async def queue_task(
@@ -314,17 +343,13 @@ class AgentLightningServer:
         resources_id: str | None = None,
         metadata: Dict[str, Any] | None = None,
     ) -> str:
-        """
-        Adds a task to the queue for a client to process.
-        """
+        """Add a task to the queue for a client to process."""
         if not self._store:
             raise RuntimeError("Store not initialized. The server may not be running.")
         return await self._store.add_task(sample, mode=mode, resources_id=resources_id, metadata=metadata)
 
     async def update_resources(self, resources: NamedResources) -> str:
-        """
-        Updates the resources, creating a new version and setting it as the latest.
-        """
+        """Publish a new resource bundle and return its generated identifier."""
         if not self._store:
             raise RuntimeError("Store not initialized. The server may not be running.")
         resources_id = f"res-{uuid.uuid4()}"
@@ -333,16 +358,20 @@ class AgentLightningServer:
         return resources_id
 
     async def get_completed_rollout(self, rollout_id: str) -> Optional[RolloutLegacy]:
-        """
-        Retrieves a specific completed rollout by its ID.
-        """
+        """Retrieve a specific completed rollout by identifier."""
         if not self._store:
             raise RuntimeError("Store not initialized. The server may not be running.")
         return await self._store.retrieve_rollout(rollout_id)
 
     async def poll_completed_rollout(self, rollout_id: str, timeout: Optional[float] = None) -> Optional[RolloutLegacy]:
-        """
-        Polls for a completed rollout by its ID, waiting up to `timeout` seconds.
+        """Poll for a completed rollout until it becomes available or a timeout expires.
+
+        Args:
+            rollout_id: Identifier of the rollout to wait for.
+            timeout: Maximum number of seconds to wait. ``None`` waits indefinitely.
+
+        Returns:
+            Retrieved rollout, or ``None`` when the timeout is reached without success.
         """
         start_time = time.time()
         while True:
@@ -354,9 +383,7 @@ class AgentLightningServer:
             await asyncio.sleep(1)
 
     async def retrieve_completed_rollouts(self) -> List[RolloutLegacy]:
-        """
-        Retrieves all available completed trajectories and clears the internal store.
-        """
+        """Return every completed rollout and clear the internal buffer."""
         if not self._store:
             raise RuntimeError("Store not initialized. The server may not be running.")
         return await self._store.retrieve_completed_rollouts()


### PR DESCRIPTION
## Summary
- rewrite legacy client and server docstrings using Google-style markdown conventions
- modernize telemetry, resource, and litagent module docstrings for clarity and linking
- standardize emitter helper documentation and add deprecation warnings where applicable

## Testing
- pre-commit

------
https://chatgpt.com/codex/tasks/task_e_68f3d9ea5a6c832eaa5983e9886f8630