### PR TITLE
force to output logs on windows.

### DIFF
--- a/agentlightning/logging.py
+++ b/agentlightning/logging.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import logging
+import os
+import platform
 
 __all__ = ["configure_logger"]
 
@@ -35,9 +37,6 @@ def configure_logger(level: int = logging.INFO, name: str = "agentlightning") ->
     # Note: This change does not fully represent support for execution under the windown system.
     # It only fixes console printing issues caused by special characters.
     # TODO: More comprehensive Windows support may be needed in the future.
-    import os
-    import platform
-
     if platform.system() == "Windows":
         os.environ["PYTHONUTF8"] = "1"
 


### PR DESCRIPTION
Issue on Windows:
_UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f914' in position 66: character maps to <undefined>_

Cause by (the emoji?): "🖇 AgentOps: You're on the agentops free plan 🤔"

fixed:
_force output utf-8 when platform is "Windows"._

