### PR TITLE
Gate example workflows on ci-* labels

### DIFF
--- a/.github/workflows/examples-apo.yml
+++ b/.github/workflows/examples-apo.yml
@@ -8,8 +8,23 @@ on:
 
   workflow_dispatch:
 
+  pull_request:
+    types: [opened, reopened, ready_for_review, labeled]
+
 jobs:
+  label-check:
+    name: Label gate (ci-apo)
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request' ||
+      ((github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'ready_for_review')
+        && contains(github.event.pull_request.labels.*.name, 'ci-apo')) ||
+      (github.event.action == 'labeled' && github.event.label.name == 'ci-apo')
+    steps:
+      - run: echo "Label requirements satisfied"
+
   apo:
+    needs: label-check
     name: APO (Python ${{ matrix.python-version }}, ${{ matrix.setup-script }})
     # This job is run on GitHub hosted runners rather than self-hosted runners because it needs no GPU.
     runs-on: ubuntu-latest

--- a/.github/workflows/examples-calc-x.yml
+++ b/.github/workflows/examples-calc-x.yml
@@ -8,8 +8,23 @@ on:
 
   workflow_dispatch:
 
+  pull_request:
+    types: [opened, reopened, ready_for_review, labeled]
+
 jobs:
+  label-check:
+    name: Label gate (ci-calc-x)
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request' ||
+      ((github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'ready_for_review')
+        && contains(github.event.pull_request.labels.*.name, 'ci-calc-x')) ||
+      (github.event.action == 'labeled' && github.event.label.name == 'ci-calc-x')
+    steps:
+      - run: echo "Label requirements satisfied"
+
   calc-x:
+    needs: label-check
     name: Calc-X (Python ${{ matrix.python-version }}, ${{ matrix.setup-script }})
     runs-on: [self-hosted, 1ES.Pool=agl-runner-gpu]
     timeout-minutes: 90

--- a/.github/workflows/examples-compat.yml
+++ b/.github/workflows/examples-compat.yml
@@ -8,8 +8,23 @@ on:
 
   workflow_dispatch:
 
+  pull_request:
+    types: [opened, reopened, ready_for_review, labeled]
+
 jobs:
+  label-check:
+    name: Label gate (ci-compat)
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request' ||
+      ((github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'ready_for_review')
+        && contains(github.event.pull_request.labels.*.name, 'ci-compat')) ||
+      (github.event.action == 'labeled' && github.event.label.name == 'ci-compat')
+    steps:
+      - run: echo "Label requirements satisfied"
+
   backward-compatibility:
+    needs: label-check
     name: Backward Compatibility (Python ${{ matrix.python-version }}, ${{ matrix.setup-script }})
     runs-on: [self-hosted, 1ES.Pool=agl-runner-gpu]
     timeout-minutes: 30

--- a/.github/workflows/examples-spider.yml
+++ b/.github/workflows/examples-spider.yml
@@ -8,8 +8,23 @@ on:
 
   workflow_dispatch:
 
+  pull_request:
+    types: [opened, reopened, ready_for_review, labeled]
+
 jobs:
+  label-check:
+    name: Label gate (ci-spider)
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request' ||
+      ((github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'ready_for_review')
+        && contains(github.event.pull_request.labels.*.name, 'ci-spider')) ||
+      (github.event.action == 'labeled' && github.event.label.name == 'ci-spider')
+    steps:
+      - run: echo "Label requirements satisfied"
+
   spider:
+    needs: label-check
     name: Spider (Python ${{ matrix.python-version }}, ${{ matrix.setup-script }})
     runs-on: [self-hosted, 1ES.Pool=agl-runner-gpu]
     timeout-minutes: 60

--- a/.github/workflows/examples-unsloth.yml
+++ b/.github/workflows/examples-unsloth.yml
@@ -8,8 +8,23 @@ on:
 
   workflow_dispatch:
 
+  pull_request:
+    types: [opened, reopened, ready_for_review, labeled]
+
 jobs:
+  label-check:
+    name: Label gate (ci-unsloth)
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request' ||
+      ((github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'ready_for_review')
+        && contains(github.event.pull_request.labels.*.name, 'ci-unsloth')) ||
+      (github.event.action == 'labeled' && github.event.label.name == 'ci-unsloth')
+    steps:
+      - run: echo "Label requirements satisfied"
+
   unsloth:
+    needs: label-check
     name: Unsloth (Python ${{ matrix.python-version }}, ${{ matrix.setup-script }})
     runs-on: [self-hosted, 1ES.Pool=agl-runner-gpu]
     timeout-minutes: 60


### PR DESCRIPTION
## Summary
- add `ready_for_review` to the pull request trigger types for the example workflows
- introduce a dedicated label-check job keyed on the corresponding `ci-*` label and require the example jobs to depend on it

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f8255add08832eb5490b8aaaa0b276