### PR TITLE
Fix model name selection when multiple servers use the same model

### DIFF
--- a/agentlightning/llm_proxy.py
+++ b/agentlightning/llm_proxy.py
@@ -707,7 +707,7 @@ class LLMProxy:
             rollout_id: Rollout identifier used for span attribution. If None, will instantiate a ProxyLLM resource.
             attempt_id: Attempt identifier used for span attribution. If None, will instantiate a ProxyLLM resource.
             model: Logical model name to use. If omitted and exactly one model
-                is configured, that model is used.
+                is configured or all models have the same name, that model is used.
             sampling_parameters: Optional default sampling parameters.
 
         Returns:
@@ -719,10 +719,16 @@ class LLMProxy:
         if model is None:
             if len(self.model_list) == 1:
                 model = self.model_list[0]["model_name"]
+            elif len(self.model_list) == 0:
+                raise ValueError("No models found in model_list. Please specify the model.")
             else:
-                raise ValueError(
-                    f"Multiple or zero models found in model_list: {self.model_list}. Please specify the model."
-                )
+                first_model_name = self.model_list[0]["model_name"]
+                if all(model_config["model_name"] == first_model_name for model_config in self.model_list):
+                    model = first_model_name
+                else:
+                    raise ValueError(
+                        f"Multiple models found in model_list: {self.model_list}. Please specify the model."
+                    )
 
         if rollout_id is None and attempt_id is None:
             return ProxyLLM(


### PR DESCRIPTION
## Summary

Fixes #196 by improving the model name selection logic in `LLMProxy` to handle the case where multiple server configurations exist for the same model (e.g., for load balancing).

## Changes

- Modified `create_llm()` in `agentlightning/llm_proxy.py` to allow automatic model selection when all configured models have the same `model_name`, even if there are multiple server configurations
- Improved error messages to distinguish between "no models configured" and "multiple different models configured" cases
- Updated docstring to reflect the new behavior

## Problem

Previously, when multiple servers were configured to serve the same model (common in distributed setups like VERL), the code would fail with:
```
ValueError: Multiple or zero models found in model_list
```

This occurred even though all servers were serving the same logical model (e.g., `Qwen/Qwen2.5-7B-Instruct`), just with different API endpoints for load balancing.

## Solution

The fix checks if all model configurations share the same `model_name`. If they do, that model name is automatically used, allowing the proxy to distribute requests across multiple servers serving the same model.

## Test plan

- Verify that single model configuration still works as before
- Verify that multiple servers with the same model name now work correctly
- Verify that multiple servers with different model names still require explicit model specification
- Verify that empty model_list produces a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)