### PR TITLE
Use pull_request_target trigger to allow fork-origin PRs to check on privileged workflows

### DIFF
--- a/.github/workflows/examples-apo.yml
+++ b/.github/workflows/examples-apo.yml
@@ -18,8 +18,6 @@ jobs:
       should-run: ${{ steps.evaluate.outputs.should-run }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
       - name: Decide whether to run
         id: evaluate
         uses: actions/github-script@v7

--- a/.github/workflows/examples-calc-x.yml
+++ b/.github/workflows/examples-calc-x.yml
@@ -18,8 +18,6 @@ jobs:
       should-run: ${{ steps.evaluate.outputs.should-run }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
       - name: Decide whether to run
         id: evaluate
         uses: actions/github-script@v7

--- a/.github/workflows/examples-compat.yml
+++ b/.github/workflows/examples-compat.yml
@@ -18,8 +18,6 @@ jobs:
       should-run: ${{ steps.evaluate.outputs.should-run }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
       - name: Decide whether to run
         id: evaluate
         uses: actions/github-script@v7

--- a/.github/workflows/examples-spider.yml
+++ b/.github/workflows/examples-spider.yml
@@ -18,8 +18,6 @@ jobs:
       should-run: ${{ steps.evaluate.outputs.should-run }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
       - name: Decide whether to run
         id: evaluate
         uses: actions/github-script@v7

--- a/.github/workflows/examples-unsloth.yml
+++ b/.github/workflows/examples-unsloth.yml
@@ -18,8 +18,6 @@ jobs:
       should-run: ${{ steps.evaluate.outputs.should-run }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
       - name: Decide whether to run
         id: evaluate
         uses: actions/github-script@v7

--- a/.github/workflows/tests-full.yml
+++ b/.github/workflows/tests-full.yml
@@ -18,8 +18,6 @@ jobs:
       should-run: ${{ steps.evaluate.outputs.should-run }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
       - name: Decide whether to run
         id: evaluate
         uses: actions/github-script@v7


### PR DESCRIPTION
I think security is not a problem because we always have a "Approve and Run Workflow" button to guard the security.


------
https://chatgpt.com/codex/tasks/task_e_68f9808363fc832eb40869fda5551f1b