### PR TITLE
Serialize docs deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,10 @@ on:
       - 'v*'
   workflow_dispatch:
 
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pages: write


### PR DESCRIPTION
## Summary
- add a concurrency group to the docs deployment workflow so only one run executes at a time

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa587f125c832e9f31431c1299b796