### PR TITLE
Use SSE for wait_for_rollouts

### DIFF
--- a/docs/deep-dive/store.md
+++ b/docs/deep-dive/store.md
@@ -201,4 +201,7 @@ agl store --port 4747
 
 !!! note
 
-    [`LightningStoreClient.wait_for_rollouts`][agentlightning.LightningStoreClient.wait_for_rollouts] intentionally enforces a tiny timeout (≤ 0.1s) to avoid blocking event loops. Poll with short timeouts or compose with `asyncio.wait_for` at a higher layer.
+    [`LightningStoreClient.wait_for_rollouts`][agentlightning.LightningStoreClient.wait_for_rollouts] streams results over
+    Server-Sent Events (SSE). The client keeps the connection open while the store waits for completions and automatically
+    reconnects in 60-second chunks for very large timeouts. Use long timeouts directly or wrap the call in
+    [`asyncio.wait_for`](https://docs.python.org/3/library/asyncio-task.html#asyncio.wait_for) if you need an overall deadline.

--- a/docs/how-to/unsloth-sft.md
+++ b/docs/how-to/unsloth-sft.md
@@ -118,7 +118,9 @@ while True:
 
 !!! note
 
-    The `timeout=0.0` is needed here because this example uses a [`LightningStoreClient`][agentlightning.LightningStoreClient], and `wait_for_rollouts` establishes an HTTP connection to that store. Currently, only non-blocking wait requests are supported, which avoids holding the store connection open.
+    [`LightningStoreClient.wait_for_rollouts`][agentlightning.LightningStoreClient.wait_for_rollouts] now streams results over
+    SSE, so you can use longer timeouts when it simplifies your loop. In this example we still poll with `timeout=0.0` to check
+    progress alongside other work, but a larger timeout would keep the connection open until the store reports completions.
 
 Once the rollouts complete, we terminate the vLLM server to free up GPU memory.
 


### PR DESCRIPTION
## Summary
- stream wait_for_rollouts responses over SSE so the client can wait for longer timeouts
- add client-side SSE handling with 60s retry chunks and document the new behavior
- extend store client tests to cover large timeout support

## Testing
- pytest tests/store/test_client_server.py -k wait_for_rollouts *(fails: ModuleNotFoundError: No module named 'opentelemetry')*

------
https://chatgpt.com/codex/tasks/task_e_68fa5a8534b4832eb5385a9bbfe33194