### PR TITLE
docs: add deepwiki badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Documentation](https://img.shields.io/badge/GitHub%20Pages-Documentation-blue)](https://microsoft.github.io/agent-lightning/)
 [![PyPI version](https://badge.fury.io/py/agentlightning.svg)](https://badge.fury.io/py/agentlightning)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/microsoft/agent-lightning)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/RYk7CdvDR7)
 
 **The absolute trainer to light up AI agents.**


### PR DESCRIPTION
## Summary
- add the Ask DeepWiki badge to the README badge list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69084b8dc44c832ea25ccfb1a34c2d38