### PR TITLE
fix room_selector example which always run the first task

### DIFF
--- a/examples/apo/room_selector.py
+++ b/examples/apo/room_selector.py
@@ -345,7 +345,7 @@ async def debug_room_selector(limit: int = 1):
         for task in tasks:
             console.print("[bold green]=== Task ===[/bold green]", task, sep="\n")
             # Run the agent
-            rollout = await runner.step(tasks[0], resources={"main_prompt": prompt_template})
+            rollout = await runner.step(task, resources={"main_prompt": prompt_template})
             # Get the spans and convert them to messages
             # Useful for debugging and analysis
             spans = await store.query_spans(rollout.rollout_id)


### PR DESCRIPTION
In the `room_selector` example, the runner incorrectly executes the first task (`tasks[0]`) on every step instead of advancing to the next one.
As a result, the example produces inconsistent outputs: the `expected_choice` and final result are mismatched, but the model is still assigned a high reward.