### PR TITLE
Add trajectory-level advantage estimation to reduce turn-level bias

### DIFF
--- a/agentlightning/verl/core_algos.py
+++ b/agentlightning/verl/core_algos.py
@@ -1,0 +1,326 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Agent Lightning's customized advantage estimators with trajectory-level deduplication.
+
+This module extends VeRL's core algorithms by overriding specific advantage estimators
+to support trajectory-level deduplication using (data_id, rollout_id) pairs.
+
+Modified algorithms:
+- GRPO: Added trajectory deduplication logic
+- GRPO_PASSK: Added trajectory deduplication logic  
+- REINFORCE_PLUS_PLUS_BASELINE: Added trajectory deduplication logic
+- RLOO: Added trajectory deduplication logic
+
+All other algorithms (GAE, OPO, REMAX, etc.) are imported from VeRL unchanged.
+"""
+
+__all__ = ["register_adv_est", "get_adv_estimator_fn", "AdvantageEstimator"]
+
+from collections import defaultdict
+from copy import deepcopy
+from typing import Any, Optional
+from enum import Enum
+
+import numpy as np
+import torch
+
+import verl.utils.torch_functional as verl_F
+
+# Import core registry infrastructure from VeRL
+from verl.trainer.ppo.core_algos import (
+    ADV_ESTIMATOR_REGISTRY,
+    AdvantageEstimator,
+    get_adv_estimator_fn,
+    # Import GAE function (used by trainer.py)
+    compute_gae_advantage_return,
+)
+
+
+def register_adv_est(name_or_enum: str | AdvantageEstimator) -> Any:
+    """Decorator to register a advantage estimator function with a given name.
+
+    Args:
+        name_or_enum: `(str)` or `(AdvantageEstimator)`
+            The name or enum of the advantage estimator.
+
+    """
+
+    def decorator(fn):
+        name = name_or_enum.value if isinstance(name_or_enum, Enum) else name_or_enum
+        ADV_ESTIMATOR_REGISTRY[name] = fn
+        return fn
+
+    return decorator
+
+
+# NOTE: this implementation only considers outcome supervision, where the reward is a scalar.
+@register_adv_est(AdvantageEstimator.GRPO)
+def compute_grpo_outcome_advantage(
+    token_level_rewards: torch.Tensor,
+    response_mask: torch.Tensor,
+    index: np.ndarray,
+    traj_index: np.ndarray,
+    epsilon: float = 1e-6,
+    norm_adv_by_std_in_grpo: str = True,
+    compute_mean_std_cross_all_data: bool = True,
+    custom_reward_mean_std: dict = {},
+    config: Optional[Any] = None,
+    **kwargs,
+):
+    """
+    Compute advantage for GRPO, operating only on Outcome reward
+    (with only one scalar reward for each response).
+    Args:
+        token_level_rewards: `(torch.Tensor)`
+            shape is (bs, response_length)
+        response_mask: `(torch.Tensor)`
+            shape is (bs, response_length)
+        norm_adv_by_std_in_grpo: (bool)
+            whether to scale the GRPO advantage.
+            If True, the advantage is scaled by the std, as in the original GRPO.
+            If False, the advantage is not scaled, as in Dr.GRPO (https://arxiv.org/abs/2503.20783).
+        compute_mean_std_cross_all_data: bool
+            If True (more stable), the mean and std are computed across all data in the batch. 
+            If False (i.e., standard episode-level adv), the mean and std are computed across N trajectories.
+
+    Returns:
+        advantages: `(torch.Tensor)`
+            shape is (bs, response_length)
+        Returns: `(torch.Tensor)`
+            shape is (bs, response_length)
+    """
+    scores = token_level_rewards.sum(dim=-1)
+    assert(scores.size(0) == response_mask.size(0))
+    id2score = defaultdict(list)
+    id2mean = {}
+    id2std = {}
+    seen_pairs = set()
+    with torch.no_grad():
+        bsz = scores.shape[0]
+        if custom_reward_mean_std == {}:
+            for i in range(bsz):
+                if (index[i], traj_index[i]) in seen_pairs:
+                    continue
+                id2score[index[i]].append(scores[i])
+                if not compute_mean_std_cross_all_data:
+                    seen_pairs.add((index[i], traj_index[i]))
+            for idx in id2score:
+                if len(id2score[idx]) == 1:
+                    id2mean[idx] = torch.tensor(0.0)
+                    id2std[idx] = torch.tensor(1.0)
+                elif len(id2score[idx]) > 1:
+                    id2mean[idx] = torch.mean(torch.tensor(id2score[idx]))
+                    id2std[idx] = torch.std(torch.tensor([id2score[idx]]))
+                else:
+                    raise ValueError(f"no score in prompt index: {idx}")
+        else:
+            custom_reward = custom_reward_mean_std["mean"]
+            custom_std = custom_reward_mean_std["std"]
+            for i in range(bsz):
+                if type(custom_reward) is list:
+                    id2mean[index[i]] = custom_reward[i]
+                else:
+                    id2mean[index[i]] = custom_reward
+                if type(custom_std) is list:
+                    id2std[index[i]] = custom_std[i]
+                else:
+                    id2std[index[i]] = custom_std
+        
+        for i in range(bsz):
+            if norm_adv_by_std_in_grpo:
+                scores[i] = (scores[i] - id2mean[index[i]]) / (id2std[index[i]] + epsilon)
+            else:
+                scores[i] = scores[i] - id2mean[index[i]]
+        scores = scores.unsqueeze(-1) * response_mask
+
+    return deepcopy(scores), deepcopy(scores)
+
+
+@register_adv_est(AdvantageEstimator.GRPO_PASSK)
+def compute_grpo_passk_outcome_advantage(
+    token_level_rewards: torch.Tensor,
+    response_mask: torch.Tensor,
+    index: np.ndarray,
+    traj_index: np.ndarray,
+    epsilon: float = 1e-6,
+    norm_adv_by_std_in_grpo: bool = True,
+    compute_mean_std_cross_all_data: bool = True,
+    config: Optional[Any] = None,
+    **kwargs,
+):
+    """
+    Compute advantage for Pass@k using a GRPO-style outcome reward formulation.
+    Only the best response per group gets a non-zero advantage: r_max - r_second_max.
+
+    Implemented as described in https://arxiv.org/abs/2503.19595.
+
+    Args:
+        token_level_rewards: (bs, response_length)
+        response_mask: (bs, response_length)
+        index: (bs,) → group ID per sample
+        epsilon: float for numerical stability
+        norm_adv_by_std_in_grpo: if True, normalize advantage by std within group
+        compute_mean_std_cross_all_data: bool
+            If True (more stable), the mean and std are computed across all data in the batch. 
+            If False (i.e., standard episode-level adv), the mean and std are computed across N trajectories.
+
+    Returns:
+        advantages: (bs, response_length)
+        returns: (bs, response_length)
+    """
+    scores = token_level_rewards.sum(dim=-1)
+    advantages = torch.zeros_like(scores)
+
+    id2scores = defaultdict(list)
+    id2indices = defaultdict(list)
+    seen_pairs = set()
+    with torch.no_grad():
+        bsz = scores.shape[0]
+        for i in range(bsz):
+            if (index[i], traj_index[i]) in seen_pairs:
+                continue
+            idx = index[i]
+            id2scores[idx].append(scores[i])
+            id2indices[idx].append(i)
+            if not compute_mean_std_cross_all_data:
+                seen_pairs.add((index[i], traj_index[i]))
+        for idx in id2scores:
+            rewards = torch.stack(id2scores[idx])  # (k,)
+            if rewards.numel() < 2:
+                raise ValueError(f"Pass@k requires at least 2 samples per group. Got {rewards.numel()} for group {idx}.")
+            topk, topk_idx = torch.topk(rewards, 2)
+            r_max, r_second_max = topk[0], topk[1]
+            i_max = id2indices[idx][topk_idx[0].item()]
+            advantage = r_max - r_second_max
+            if norm_adv_by_std_in_grpo:
+                std = torch.std(rewards)
+                advantage = advantage / (std + epsilon)
+            advantages[i_max] = advantage
+
+    advantages = advantages.unsqueeze(-1) * response_mask
+    return advantages, advantages
+
+
+@register_adv_est(AdvantageEstimator.REINFORCE_PLUS_PLUS_BASELINE)
+def compute_reinforce_plus_plus_baseline_outcome_advantage(
+    token_level_rewards: torch.Tensor,
+    response_mask: torch.Tensor,
+    index: torch.Tensor,
+    traj_index: np.ndarray,
+    reward_baselines: torch.Tensor,
+    epsilon: float = 1e-6,
+    compute_mean_std_cross_all_data: bool = True,
+    config: Optional[Any] = None,
+    **kwargs,
+):
+    """
+    Compute advantage for RF++-baseline (https://arxiv.org/abs/2501.03262), operating only on Outcome reward
+    (with only one scalar reward for each response).
+    Args:
+        token_level_rewards: `(torch.Tensor)`
+            shape: (bs, response_length)
+        response_mask: `(torch.Tensor)`
+            shape: (bs, response_length)
+
+    Returns:
+        advantages: `(torch.Tensor)`
+            shape: (bs, response_length)
+        Returns: `(torch.Tensor)`
+            shape: (bs, response_length)
+    """
+    response_length = token_level_rewards.shape[-1]
+    scores = token_level_rewards.sum(dim=-1)
+
+    id2score = defaultdict(list)
+    id2mean = {}
+    seen_pairs = set()
+    with torch.no_grad():
+        bsz = scores.shape[0]
+        for i in range(bsz):
+            if (index[i], traj_index[i]) in seen_pairs:
+                continue
+            id2score[index[i]].append(scores[i])
+            if not compute_mean_std_cross_all_data:
+                seen_pairs.add((index[i], traj_index[i]))
+        for idx in id2score:
+            if len(id2score[idx]) == 1:
+                id2mean[idx] = torch.tensor(0.0)
+            elif len(id2score[idx]) > 1:
+                id2mean[idx] = torch.mean(torch.tensor(id2score[idx]))
+            else:
+                raise ValueError(f"no score in prompt index: {idx}")
+        for i in range(bsz):
+            scores[i] = scores[i] - id2mean[index[i]]
+
+        scores = scores.unsqueeze(-1).tile([1, response_length]) * response_mask
+        scores = verl_F.masked_whiten(scores, response_mask) * response_mask
+
+    return scores, scores
+
+
+@register_adv_est(AdvantageEstimator.RLOO)
+def compute_rloo_outcome_advantage(
+    token_level_rewards: torch.Tensor,
+    response_mask: torch.Tensor,
+    index: np.ndarray,
+    traj_index: np.ndarray,
+    epsilon: float = 1e-6,
+    compute_mean_std_cross_all_data: bool = True,
+    config: Optional[Any] = None,
+    **kwargs,
+):
+    """
+    Compute advantage for RLOO based on https://arxiv.org/abs/2402.14740
+    Args:
+        token_level_rewards: `(torch.Tensor)`
+            shape: (bs, response_length)
+        response_mask: `(torch.Tensor)`
+            shape: (bs, response_length)
+
+    Returns:
+        advantages: `(torch.Tensor)`
+            shape: (bs, response_length)
+        Returns: `(torch.Tensor)`
+            shape: (bs, response_length)
+    """
+    scores = token_level_rewards.sum(dim=-1)
+
+    id2score = defaultdict(list)
+    id2mean = {}
+    seen_pairs = set()
+    with torch.no_grad():
+        bsz = scores.shape[0]
+        for i in range(bsz):
+            if (index[i], traj_index[i]) in seen_pairs:
+                continue
+            id2score[index[i]].append(scores[i])
+            if not compute_mean_std_cross_all_data:
+                seen_pairs.add((index[i], traj_index[i]))
+        for idx in id2score:
+            if len(id2score[idx]) == 1:
+                id2mean[idx] = torch.tensor(0.0)
+            elif len(id2score[idx]) > 1:
+                id2mean[idx] = torch.mean(torch.tensor(id2score[idx]))
+            else:
+                raise ValueError(f"no score in prompt index: {idx}")
+        for i in range(bsz):
+            response_num = len(id2score[index[i]])
+            if response_num > 1:
+                scores[i] = scores[i] * response_num / (response_num - 1) - id2mean[index[i]] * response_num / (response_num - 1)
+        scores = scores.unsqueeze(-1) * response_mask
+
+    return scores, scores
+

--- a/agentlightning/verl/trainer.py
+++ b/agentlightning/verl/trainer.py
@@ -28,7 +28,6 @@ from verl.trainer.ppo.ray_trainer import (
     AdvantageEstimator,
     RayPPOTrainer,
     apply_kl_penalty,
-    compute_advantage,
     compute_response_mask,
 )
 from verl.utils.metric import reduce_metrics
@@ -38,11 +37,95 @@ from agentlightning.adapter import TraceAdapter, TraceToTripletBase
 from agentlightning.llm_proxy import LLMProxy
 from agentlightning.store.base import LightningStore
 
+from . import core_algos
 from .daemon import AgentModeDaemon
 
 __all__ = [
     "AgentLightningTrainer",
 ]
+
+
+def compute_advantage(
+    batch: DataProto,
+    adv_estimator: AdvantageEstimator,
+    gamma: float = 1.0,
+    lam: float = 1.0,
+    num_repeat: int = 1,
+    norm_adv_by_std_in_grpo: bool = True,
+    compute_mean_std_cross_all_data: bool = True,
+    config: Any = None,
+) -> DataProto:
+    """Compute advantage estimates for policy optimization.
+
+    This function computes advantage estimates using various estimators like GAE, GRPO, REINFORCE++, etc.
+    The advantage estimates are used to guide policy optimization in RL algorithms.
+
+    Args:
+        batch: DataProto object containing batch data
+        adv_estimator: The advantage estimator to use (e.g., GAE, GRPO, REINFORCE++)
+        gamma: Discount factor for future rewards
+        lam: Lambda parameter for GAE
+        num_repeat: Number of rollouts per sample
+        norm_adv_by_std_in_grpo: Whether to normalize by std in GRPO
+        compute_mean_std_cross_all_data: Whether to compute mean/std across all data
+        config: Additional configuration dictionary
+
+    Returns:
+        Updated batch with advantages and returns computed
+    """
+    # Ensure response_mask exists
+    if "response_mask" not in batch.batch:
+        batch.batch["response_mask"] = compute_response_mask(batch)
+
+    if adv_estimator == AdvantageEstimator.GAE:
+        # Compute advantages using Generalized Advantage Estimation (GAE)
+        advantages, returns = core_algos.compute_gae_advantage_return(
+            token_level_rewards=batch.batch["token_level_rewards"],
+            values=batch.batch["values"],
+            response_mask=batch.batch["response_mask"],
+            gamma=gamma,
+            lam=lam,
+        )
+        batch.batch["advantages"] = advantages
+        batch.batch["returns"] = returns
+    elif adv_estimator == AdvantageEstimator.GRPO:
+        # GRPO with trajectory-level deduplication
+        advantages, returns = core_algos.compute_grpo_outcome_advantage(
+            token_level_rewards=batch.batch["token_level_rewards"],
+            response_mask=batch.batch["response_mask"],
+            index=batch.non_tensor_batch["data_id_list"],
+            traj_index=batch.non_tensor_batch["rollout_id_list"],
+            norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
+            compute_mean_std_cross_all_data=compute_mean_std_cross_all_data,
+        )
+        batch.batch["advantages"] = advantages
+        batch.batch["returns"] = returns
+    else:
+        # Handle all other advantage estimator types
+        adv_estimator_fn = core_algos.get_adv_estimator_fn(adv_estimator)
+        adv_kwargs = {
+            "token_level_rewards": batch.batch["token_level_rewards"],
+            "response_mask": batch.batch["response_mask"],
+            "config": config,
+        }
+        # Add optional parameters if available
+        if "data_id_list" in batch.non_tensor_batch:
+            adv_kwargs["index"] = batch.non_tensor_batch["data_id_list"]
+        if "rollout_id_list" in batch.non_tensor_batch:
+            adv_kwargs["traj_index"] = batch.non_tensor_batch["rollout_id_list"]
+        if "reward_baselines" in batch.batch:
+            adv_kwargs["reward_baselines"] = batch.batch["reward_baselines"]
+
+        # Add GRPO-related parameters
+        adv_kwargs["norm_adv_by_std_in_grpo"] = norm_adv_by_std_in_grpo
+        adv_kwargs["compute_mean_std_cross_all_data"] = compute_mean_std_cross_all_data
+        adv_kwargs["gamma"] = gamma
+
+        advantages, returns = adv_estimator_fn(**adv_kwargs)
+        batch.batch["advantages"] = advantages
+        batch.batch["returns"] = returns
+
+    return batch
 
 
 @contextmanager
@@ -350,11 +433,14 @@ class AgentLightningTrainer(RayPPOTrainer):
                     batch.batch["token_level_rewards"] = batch.batch["token_level_scores"]
 
                 # compute advantages, executed on the driver process
-
                 norm_adv_by_std_in_grpo = self.config.algorithm.get(
                     "norm_adv_by_std_in_grpo", True
                 )  # GRPO adv normalization factor
-
+                compute_mean_std_cross_all_data = self.config.algorithm.get(
+                    "compute_mean_std_cross_all_data", True
+                )
+                
+                # Unified entry point for all advantage estimation algorithms
                 batch = compute_advantage(
                     batch,
                     adv_estimator=self.config.algorithm.adv_estimator,
@@ -362,6 +448,7 @@ class AgentLightningTrainer(RayPPOTrainer):
                     lam=self.config.algorithm.lam,
                     num_repeat=self.config.actor_rollout_ref.rollout.n,
                     norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
+                    compute_mean_std_cross_all_data=compute_mean_std_cross_all_data,
                     config=self.config.algorithm,
                 )
 


### PR DESCRIPTION
## Problem

Agent-lightning inherits VeRL's default advantage estimation, which assumes each batch sample is independent. In multi-turn scenarios, this causes **turn-level bias**: trajectories with more turns contribute more to baseline statistics (mean/std), leading to biased advantage estimation and inefficient optimization.

## Solution

Implements trajectory-level deduplication using `(data_id, rollout_id)` pairs. Set `trainer.compute_mean_std_cross_all_data=False` to ensure each trajectory is counted only once when computing baselines.

In `agentlightning.verl.core_algos`, we re-register part of VeRL's `adv_estimator_fn` implementations to integrate the new trajectory-level deduplication logic.

```Python
seen_pairs = set()
for i in range(bsz):
    if (index[i], traj_index[i]) in seen_pairs:
        continue  # Skip duplicate turns from same trajectory
    id2score[index[i]].append(scores[i])
    if not compute_mean_std_cross_all_data:
        seen_pairs.add((index[i], traj_index[i]))
```

## Example Configuration

Control the normalization behavior via the `compute_mean_std_cross_all_data` parameter:

- **`compute_mean_std_cross_all_data=True`** (default): Cross-all-data normalization, more stable but still counts each turn
- **`compute_mean_std_cross_all_data=False`**: Trajectory-level normalization - each trajectory counted only once, eliminates bias

```Python
config = {
    "algorithm": {
        "adv_estimator": "grpo",
        "norm_adv_by_std_in_grpo": True,
        "compute_mean_std_cross_all_data": False,  # Enable trajectory-level
    }
}
```

## Implementation

**Affected algorithms**:

- ✅ GRPO
- ✅ GRPO Pass@k
- ✅ REINFORCE++ Baseline
- ✅ RLOO

**Files modified**:

- `agentlightning/verl/core_algos.py`: Trajectory-aware advantage estimators
- `agentlightning/verl/trainer.py`: Unified `compute_advantage` entry point