### PR TITLE
Fix mRoPE position ID crash on Qwen2-VL prompt truncation

### DIFF
--- a/agentlightning/verl/daemon.py
+++ b/agentlightning/verl/daemon.py
@@ -310,6 +310,45 @@ class AgentModeDaemon:
             raise ValueError(f"Relative path '{path}' requires 'image_base_dir' to be set.")
         return os.path.join(self.image_base_dir, path)
 
+    def _count_images_in_tokens(self, token_ids: List[int]) -> int:
+        """Count the number of complete image regions in a token ID sequence.
+
+        Image regions are identified by finding ``vision_start_token_id``
+        followed by ``image_token_id``, matching the detection logic used by
+        ``get_rope_index`` in the Qwen2-VL / Qwen2.5-VL model implementation.
+        This is needed to reconcile ``image_grid_thw`` with truncated prompts
+        so that mRoPE position IDs are computed correctly.
+
+        Args:
+            token_ids: List of token IDs (possibly truncated).
+
+        Returns:
+            Number of image regions found in the token sequence, or ``-1`` if
+            the required special-token IDs could not be resolved (in which case
+            the caller should fall back to the original image count).
+        """
+        # Resolve image_token_id from the processor (set during __init__)
+        image_token_id = getattr(self.processor, "image_token_id", None)
+        if image_token_id is None and hasattr(self.tokenizer, "convert_tokens_to_ids"):
+            image_token_id = self.tokenizer.convert_tokens_to_ids("<|image_pad|>")
+
+        # Resolve vision_start_token_id -- not stored on the processor, so we
+        # try the tokenizer first and fall back to the well-known default.
+        vision_start_token_id = None
+        if hasattr(self.tokenizer, "convert_tokens_to_ids"):
+            vision_start_token_id = self.tokenizer.convert_tokens_to_ids("<|vision_start|>")
+        if vision_start_token_id is None:
+            vision_start_token_id = 151652  # Qwen2-VL / Qwen2.5-VL default
+
+        if image_token_id is None:
+            return -1
+
+        count = 0
+        for i in range(len(token_ids) - 1):
+            if token_ids[i] == vision_start_token_id and token_ids[i + 1] == image_token_id:
+                count += 1
+        return count
+
     def _get_image_grid_thw(self, image_urls: List[str]) -> Optional[torch.Tensor]:
         """Compute image_grid_thw from image URLs for M-RoPE computation.
 
@@ -907,9 +946,17 @@ class AgentModeDaemon:
                     rollout_id_list.append(rollout_id)
                     turn_index_list.append(turn_index)
 
-                    # Compute image_grid_thw for this triplet using image_urls from prompt
+                    # Compute image_grid_thw for this triplet using image_urls from prompt.
+                    # After prompt truncation, some image tokens may have been removed,
+                    # so we must reconcile image_urls with the actual images remaining
+                    # in the (possibly truncated) prompt to avoid shape mismatches in
+                    # get_rope_index when computing mRoPE position IDs.
                     if self._use_mrope:
                         image_urls = trace.get("image_urls", [])
+                        if image_urls:
+                            n_images_in_tokens = self._count_images_in_tokens(prompt_ids)
+                            if n_images_in_tokens >= 0 and n_images_in_tokens < len(image_urls):
+                                image_urls = image_urls[:n_images_in_tokens]
                         image_grid_thw_list.append(self._get_image_grid_thw(image_urls))
 
         elif self.trace_aggregator.get("level", "transition") == "trajectory":

--- a/agentlightning/verl/daemon.py
+++ b/agentlightning/verl/daemon.py
@@ -1088,12 +1088,22 @@ class AgentModeDaemon:
             # For Qwen2-VL: compute 4D position_ids (batch_size, 4, seq_length)
             position_ids_list: list[torch.Tensor] = []
             for i in range(n_transition):
-                pos_ids = self._compute_mrope_position_ids(
-                    input_ids=batch_seq[i],
-                    attention_mask=attention_mask[i],
-                    image_grid_thw=image_grid_thw_list[i] if image_grid_thw_list else None,
-                )  # (4, seq_length)
-                position_ids_list.append(pos_ids)
+                if is_drop_list[i]:
+                    # Skip get_rope_index for dropped samples (e.g. truncated
+                    # image in the middle of the prompt) — it would crash.
+                    # is_drop_mask removes this sample in the trainer, so the
+                    # placeholder pos_ids are never used.
+                    seq_len = batch_seq[i].size(0)
+                    position_ids_list.append(
+                        torch.zeros(4, seq_len, dtype=torch.long, device=device)
+                    )
+                else:
+                    pos_ids = self._compute_mrope_position_ids(
+                        input_ids=batch_seq[i],
+                        attention_mask=attention_mask[i],
+                        image_grid_thw=image_grid_thw_list[i] if image_grid_thw_list else None,
+                    )  # (4, seq_length)
+                    position_ids_list.append(pos_ids)
             # Stack to (batch_size, 4, seq_length)
             position_ids = torch.stack(position_ids_list, dim=0)
         else:


### PR DESCRIPTION
## Summary

Fixes #441

When training Qwen2.5-VL with agent-lightning + verl, the model crashes in `get_rope_index` with a shape mismatch:

```
position_ids[..., attention_mask == 1] = llm_positions
```

fails because `llm_positions` length differs from the attention mask true-count.

**Root cause:** In `get_train_data_batch`, prompt truncation (`prompt_ids[:max_prompt_length]`) changes the token count, potentially removing image placeholder tokens. However, `image_grid_thw` is computed from the original (untruncated) `image_urls` list. When `get_rope_index` processes the truncated sequence, it finds fewer `<|vision_start|><|image_pad|>` regions than `image_grid_thw` entries, causing the position ID length to diverge from the attention mask count.

**Fix:** After prompt truncation, count the remaining image regions in the truncated token sequence using the same `vision_start_token_id` + `image_token_id` pattern that `get_rope_index` uses, and slice `image_urls` to match before computing `image_grid_thw`.

- Added `_count_images_in_tokens()` helper method to detect image regions in token sequences
- Modified the transition-level mRoPE code path to reconcile `image_urls` with truncated prompts

## Test plan

- [ ] Verify Qwen2.5-VL training with prompts that exceed `max_prompt_length` and contain images no longer crashes in `get_rope_index`
- [ ] Verify Qwen2.5-VL training with prompts shorter than `max_prompt_length` is unaffected (no truncation, all images retained)
- [ ] Verify non-VL model training paths are unaffected (`_use_mrope` is `False`)