### PR TITLE
Fix KeyError in convert_to_openai_messages for incomplete messages

### DIFF
--- a/agentlightning/adapter/messages.py
+++ b/agentlightning/adapter/messages.py
@@ -131,11 +131,18 @@ def convert_to_openai_messages(prompt_completion_list: List[_RawSpanInfo]) -> Ge
 
         # Extract messages
         for msg in pc_entry["prompt"]:
-            role = msg["role"]
+            # Infer role from tool_calls presence when role key is missing;
+            # skip messages that have neither role nor tool_calls.
+            if "role" not in msg:
+                if "tool_calls" in msg:
+                    role = "assistant"
+                else:
+                    continue
+            else:
+                role = msg["role"]
 
             if role == "assistant" and "tool_calls" in msg:
                 # Use the tool_calls directly
-                # This branch is usually not used in the wild.
                 tool_calls: List[ChatCompletionMessageFunctionToolCallParam] = [
                     ChatCompletionMessageFunctionToolCallParam(
                         id=call["id"],
@@ -143,10 +150,12 @@ def convert_to_openai_messages(prompt_completion_list: List[_RawSpanInfo]) -> Ge
                         function={"name": call["name"], "arguments": call["arguments"]},
                     )
                     for call in msg["tool_calls"]
+                    if "id" in call and "name" in call and "arguments" in call
                 ]
-                messages.append(
-                    ChatCompletionAssistantMessageParam(role="assistant", content=None, tool_calls=tool_calls)
-                )
+                if tool_calls:
+                    messages.append(
+                        ChatCompletionAssistantMessageParam(role="assistant", content=None, tool_calls=tool_calls)
+                    )
             else:
                 # Normal user/system/tool content
                 message = cast(
@@ -169,10 +178,22 @@ def convert_to_openai_messages(prompt_completion_list: List[_RawSpanInfo]) -> Ge
                             function={"name": tool["name"], "arguments": tool["parameters"]},
                         )
                         for tool in pc_entry["tools"]
+                        if isinstance(tool.get("call"), dict)
+                        and "id" in tool["call"]
+                        and "type" in tool["call"]
+                        and "name" in tool
+                        and "parameters" in tool
                     ]
-                    messages.append(
-                        ChatCompletionAssistantMessageParam(role="assistant", content=content, tool_calls=tool_calls)
-                    )
+                    if tool_calls:
+                        messages.append(
+                            ChatCompletionAssistantMessageParam(
+                                role="assistant", content=content, tool_calls=tool_calls
+                            )
+                        )
+                    else:
+                        messages.append(
+                            ChatCompletionAssistantMessageParam(role="assistant", content=content)
+                        )
                 else:
                     messages.append(ChatCompletionAssistantMessageParam(role="assistant", content=content))
 

--- a/tests/adapter/test_messages_adapter.py
+++ b/tests/adapter/test_messages_adapter.py
@@ -391,3 +391,114 @@ def test_trace_messages_adapter_handles_multiple_tool_calls():
     ]
 
     assert adapter.adapt(spans) == expected
+
+
+@pytest.mark.skipif(
+    _skip_for_openai_lt_1_100_0,
+    reason="Requires openai>=1.100.0",
+)
+def test_convert_to_openai_messages_skips_messages_missing_role():
+    """Messages without a role key and no tool_calls should be silently skipped."""
+    spans = [
+        make_span(
+            "openai.chat.completion",
+            {
+                "gen_ai.prompt.0.content": "orphaned content",
+                "gen_ai.prompt.1.role": "user",
+                "gen_ai.prompt.1.content": "Hello",
+                "gen_ai.completion.0.role": "assistant",
+                "gen_ai.completion.0.content": "Hi there",
+                "gen_ai.completion.0.finish_reason": "stop",
+            },
+            0,
+        ),
+    ]
+
+    adapter = TraceToMessages()
+    result = adapter.adapt(spans)
+
+    assert len(result) == 1
+    assert result[0]["messages"] == [
+        {"content": "Hello", "role": "user"},
+        {"content": "Hi there", "role": "assistant"},
+    ]
+    assert result[0]["tools"] is None
+
+
+@pytest.mark.skipif(
+    _skip_for_openai_lt_1_100_0,
+    reason="Requires openai>=1.100.0",
+)
+def test_convert_to_openai_messages_skips_tool_calls_missing_keys():
+    """Tool call entries missing required keys should be filtered out."""
+    spans = [
+        make_span(
+            "openai.chat.completion",
+            {
+                "gen_ai.prompt.0.role": "user",
+                "gen_ai.prompt.0.content": "Do something",
+                "gen_ai.prompt.1.role": "assistant",
+                "gen_ai.prompt.1.tool_calls.0.id": "call_abc",
+                "gen_ai.prompt.1.tool_calls.0.name": "my_tool",
+                "gen_ai.prompt.1.tool_calls.0.arguments": "{}",
+                "gen_ai.prompt.1.tool_calls.1.name": "bad_tool",
+                "gen_ai.prompt.1.tool_calls.1.arguments": "{}",
+                "gen_ai.completion.0.role": "assistant",
+                "gen_ai.completion.0.content": "Done",
+                "gen_ai.completion.0.finish_reason": "stop",
+            },
+            0,
+        ),
+    ]
+
+    adapter = TraceToMessages()
+    result = adapter.adapt(spans)
+
+    assert len(result) == 1
+    assistant_msg = result[0]["messages"][1]
+    assert assistant_msg["role"] == "assistant"
+    assert len(assistant_msg["tool_calls"]) == 1
+    assert assistant_msg["tool_calls"][0]["id"] == "call_abc"
+
+
+@pytest.mark.skipif(
+    _skip_for_openai_lt_1_100_0,
+    reason="Requires openai>=1.100.0",
+)
+def test_convert_to_openai_messages_infers_assistant_role_from_tool_calls():
+    """When role is missing but tool_calls are present, infer role=assistant."""
+    tool_name = "get_weather"
+    tool_call_id = "call_abc123"
+    tool_parameters = json.dumps({"location": "Seattle"})
+
+    spans = [
+        make_span(
+            "openai.chat.completion",
+            {
+                "gen_ai.prompt.0.role": "user",
+                "gen_ai.prompt.0.content": "What is the weather?",
+                "gen_ai.prompt.1.tool_calls.0.id": tool_call_id,
+                "gen_ai.prompt.1.tool_calls.0.name": tool_name,
+                "gen_ai.prompt.1.tool_calls.0.arguments": tool_parameters,
+                "gen_ai.prompt.2.role": "tool",
+                "gen_ai.prompt.2.content": '{"temp": 55}',
+                "gen_ai.prompt.2.tool_call_id": tool_call_id,
+                "gen_ai.completion.0.role": "assistant",
+                "gen_ai.completion.0.content": "It is 55F.",
+                "gen_ai.completion.0.finish_reason": "stop",
+            },
+            0,
+        ),
+    ]
+
+    adapter = TraceToMessages()
+    result = adapter.adapt(spans)
+
+    assert len(result) == 1
+    messages = result[0]["messages"]
+    assert len(messages) == 4
+    roles = [m["role"] for m in messages]
+    assert roles == ["user", "assistant", "tool", "assistant"]
+    assert messages[1]["content"] is None
+    assert len(messages[1]["tool_calls"]) == 1
+    assert messages[1]["tool_calls"][0]["id"] == tool_call_id


### PR DESCRIPTION
## Summary

- Add defensive key checking in `convert_to_openai_messages()` to handle incomplete message objects captured by AgentOps
- When a message lacks `"role"` but has `"tool_calls"`, infer `role="assistant"` instead of crashing; skip messages missing both keys
- Filter out individual tool_call entries missing required keys (`"id"`, `"name"`, `"arguments"`) rather than raising `KeyError`
- Guard completion tool entries against missing nested `"call"` dict or its required `"id"`/`"type"` keys
- Fall back to content-only assistant message when all tool entries are filtered out

Fixes #311

## Test plan

- [x] Existing tests pass (`test_trace_messages_adapter_builds_expected_conversations`, `test_trace_messages_adapter_handles_multiple_tool_calls`)
- [x] New test: `test_convert_to_openai_messages_skips_messages_missing_role` -- verifies messages without `"role"` are skipped
- [x] New test: `test_convert_to_openai_messages_skips_tool_calls_missing_keys` -- verifies incomplete tool_call entries are filtered
- [x] New test: `test_convert_to_openai_messages_infers_assistant_role_from_tool_calls` -- verifies role inference from `tool_calls` presence