### PR TITLE
fix: pass gts argument in _dump_generations call in _train_step

### DIFF
--- a/agentlightning/verl/trainer.py
+++ b/agentlightning/verl/trainer.py
@@ -417,10 +417,14 @@ class AgentLightningTrainer(RayPPOTrainer):
                     print(batch.batch.keys())
                     inputs = self.tokenizer.batch_decode(batch.batch["prompts"], skip_special_tokens=True)
                     outputs = self.tokenizer.batch_decode(batch.batch["responses"], skip_special_tokens=True)
+                    sample_gts = [
+                        item.non_tensor_batch.get("reward_model", {}).get("ground_truth", None) for item in batch
+                    ]
                     scores = batch.batch["token_level_scores"].sum(-1).cpu().tolist()
                     self._dump_generations(
                         inputs=inputs,
                         outputs=outputs,
+                        gts=sample_gts,
                         scores=scores,
                         reward_extra_infos_dict=reward_extra_infos_dict,
                         dump_path=rollout_data_dir,


### PR DESCRIPTION
## Summary

Fixes the `TypeError` caused by missing `gts` argument when calling `_dump_generations` in `_train_step` with `rollout_data_dir` enabled.

Closes #492

## Root Cause

`_dump_generations` requires `gts` as a positional argument, but the call site in `_train_step` did not pass it, resulting in a `TypeError` at runtime.

## Changes

Extract `ground_truth` from each sample's `non_tensor_batch` and pass it as `gts` to `_dump_generations`:

```python
sample_gts = [item.non_tensor_batch.get("reward_model", {}).get("ground_truth", None) for item in batch]
self._dump_generations(
    inputs=inputs,
    outputs=outputs,
    scores=scores,
    gts=sample_gts,
    reward_extra_infos_dict=reward_extra_infos_dict,
    dump_path=rollout_data_dir,
)
```

`ground_truth` is retrieved from `reward_model` in `non_tensor_batch` if available, otherwise falls back to `None`.

## Testing

- Verified the fix resolves the `TypeError` when `rollout_data_dir` is set in trainer config
- Tested with cases where `ground_truth` is present and absent in `non_tensor_batch`

## Environment

- Version: `v0.3.0`
- File: `agentlightning/verl/trainer.py`
- Class: `RayPPOTrainer`