### PR TITLE
Update litellm[proxy] version constraints to avoid compromised versions.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "opentelemetry-api>=1.35",
   "opentelemetry-sdk>=1.35",
   "opentelemetry-exporter-otlp>=1.35",
-  "litellm[proxy]>=1.74",
+  "litellm[proxy]>=1.74, <=1.82.6",                      # For LiteLLM tests. Upper bound pinned: versions 1.82.7+ compromised in supply chain attack.",
   "pydantic>=2.11",
   "openai",
   "rich",
@@ -109,7 +109,7 @@ torch-stable = [
   # Similar issues with vLLM 0.11.2 and 0.12.0
   "vllm>=0.10.2,!=0.11.1,!=0.11.2,!=0.12.0",
   # LiteLLM can then be upgraded with new vLLM
-  "litellm[proxy]>=1.78",
+  "litellm[proxy]>=1.78, <=1.82.6",                      # For LiteLLM tests. Upper bound pinned: versions 1.82.7+ compromised in supply chain attack.",
 ]
 torch-legacy = [
   {include-group = "core-legacy"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "opentelemetry-api>=1.35",
   "opentelemetry-sdk>=1.35",
   "opentelemetry-exporter-otlp>=1.35",
-  "litellm[proxy]>=1.74, <=1.82.6",                      # For LiteLLM tests. Upper bound pinned: versions 1.82.7+ compromised in supply chain attack.",
+  "litellm[proxy]>=1.74,<=1.82.6",                      # For LiteLLM tests. Upper bound pinned: versions 1.82.7+ compromised in supply chain attack.",
   "pydantic>=2.11",
   "openai",
   "rich",
@@ -109,7 +109,7 @@ torch-stable = [
   # Similar issues with vLLM 0.11.2 and 0.12.0
   "vllm>=0.10.2,!=0.11.1,!=0.11.2,!=0.12.0",
   # LiteLLM can then be upgraded with new vLLM
-  "litellm[proxy]>=1.78, <=1.82.6",                      # For LiteLLM tests. Upper bound pinned: versions 1.82.7+ compromised in supply chain attack.",
+  "litellm[proxy]>=1.78,<=1.82.6",                      # For LiteLLM tests. Upper bound pinned: versions 1.82.7+ compromised in supply chain attack.",
 ]
 torch-legacy = [
   {include-group = "core-legacy"},
@@ -119,7 +119,7 @@ torch-legacy = [
   "transformers==4.53.3",
   "tokenizers>=0.21,<0.22",
   "vllm==0.9.2",
-  "litellm[proxy]==1.74.15",
+  "litellm[proxy]==1.74.15,!=1.82.7,!=1.82.8", 
 ]
 
 # Specific vllm versions for compatibility testing or workarounds.


### PR DESCRIPTION
Pinned upper bound for litellm[proxy] to avoid compromised versions 1.82.7 / 1.82.8

Details on https://github.com/BerriAI/litellm/issues/24518

Replicated like in:
* https://github.com/google/adk-python/blob/main/pyproject.toml#L129 
* https://github.com/ag2ai/ag2/pull/2512