### PR TITLE
Fix #511: Question about Code Availability for EMPO^2 Paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ To start using Agent-lightning, check out our [documentation](https://microsoft.
 
 ## ⚡ Articles
 
+- *Exploratory Memory-Augmented LLM Agent via Hybrid On- and Off-Policy Optimization* (EMPO²) arXiv paper. The corresponding implementation code is being prepared and will be released in this repository.
 - 12/17/2025 [Adopting the Trajectory Level Aggregation for Faster Training](https://agent-lightning.github.io/posts/trajectory_level_aggregation/) Agent-lightning blog.
 - 11/4/2025 [Tuning ANY AI agent with Tinker ✕ Agent-lightning](https://medium.com/@yugez/tuning-any-ai-agent-with-tinker-agent-lightning-part-1-1d8c9a397f0e) Medium. See also [Part 2](https://medium.com/@yugez/tuning-any-ai-agent-with-tinker-agent-lightning-part-2-332c5437f0dc).
 - 10/22/2025 [No More Retokenization Drift: Returning Token IDs via the OpenAI Compatible API Matters in Agent RL](https://blog.vllm.ai/2025/10/22/agent-lightning.html) vLLM blog. See also [Zhihu writeup](https://zhuanlan.zhihu.com/p/1965067274642785725).


### PR DESCRIPTION
Closes #511

Adds a notice in `README.md` that the EMPO² paper's implementation code is forthcoming in this repository.

## Changes

- **`README.md`** — Inserted a new bullet at the top of the `⚡ Articles` section (line 49) announcing the *Exploratory Memory-Augmented LLM Agent via Hybrid On- and Off-Policy Optimization* (EMPO²) arXiv paper and explicitly stating that the corresponding implementation is being prepared and will be released in this repository.

## Motivation

The paper references this repository as the home for the open-sourced implementation, but the repo contained no mention of the paper or its code status. This caused confusion for users (e.g., Issue #511) who arrived expecting to find the code and found no indication of whether it had been released or was planned. The added entry sets clear expectations without misrepresenting the current state of the code.

## Testing

- Rendered `README.md` locally to confirm the new bullet appears correctly formatted under the `⚡ Articles` header and is ordered before the existing dated entries.
- Verified all existing links in the section remain intact and unmodified.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*