### PR TITLE
fix: pass missing gts argument to _dump_generations call

### DIFF
--- a/agentlightning/verl/trainer.py
+++ b/agentlightning/verl/trainer.py
@@ -414,13 +414,13 @@ class AgentLightningTrainer(RayPPOTrainer):
             rollout_data_dir = self.config.trainer.get("rollout_data_dir", None)
             if rollout_data_dir:
                 with _timer("dump_rollout_generations", timing_raw):
-                    print(batch.batch.keys())
                     inputs = self.tokenizer.batch_decode(batch.batch["prompts"], skip_special_tokens=True)
                     outputs = self.tokenizer.batch_decode(batch.batch["responses"], skip_special_tokens=True)
                     scores = batch.batch["token_level_scores"].sum(-1).cpu().tolist()
                     self._dump_generations(
                         inputs=inputs,
                         outputs=outputs,
+                        gts=None,
                         scores=scores,
                         reward_extra_infos_dict=reward_extra_infos_dict,
                         dump_path=rollout_data_dir,

--- a/agentlightning/verl/trainer.py
+++ b/agentlightning/verl/trainer.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import inspect
 import random
 from contextlib import contextmanager
 from copy import deepcopy
@@ -417,14 +418,20 @@ class AgentLightningTrainer(RayPPOTrainer):
                     inputs = self.tokenizer.batch_decode(batch.batch["prompts"], skip_special_tokens=True)
                     outputs = self.tokenizer.batch_decode(batch.batch["responses"], skip_special_tokens=True)
                     scores = batch.batch["token_level_scores"].sum(-1).cpu().tolist()
-                    self._dump_generations(
+                    dump_kwargs = dict(
                         inputs=inputs,
                         outputs=outputs,
-                        gts=None,
                         scores=scores,
                         reward_extra_infos_dict=reward_extra_infos_dict,
                         dump_path=rollout_data_dir,
                     )
+                    # verl >=0.6.0 added a required `gts` (ground truths) parameter to
+                    # `_dump_generations`; verl 0.5.0 (CI-pinned) does not have it. Ground
+                    # truth is unavailable in agent-mode training, so feature-detect the
+                    # signature and only pass `gts=None` when the parameter exists.
+                    if "gts" in inspect.signature(self._dump_generations).parameters:
+                        dump_kwargs["gts"] = None
+                    self._dump_generations(**dump_kwargs)
 
         # compute training metrics
         metrics.update(compute_data_metrics(batch=batch, use_critic=self.use_critic, suffix="_after_processing"))

--- a/contrib/agentlightning/contrib/algorithm/env_verl/trainer.py
+++ b/contrib/agentlightning/contrib/algorithm/env_verl/trainer.py
@@ -514,13 +514,13 @@ class EnvAgentLightningTrainer(RayPPOTrainer):
             rollout_data_dir = self.config.trainer.get("rollout_data_dir", None)
             if rollout_data_dir:
                 with _timer("dump_rollout_generations", timing_raw):
-                    print(batch.batch.keys())
                     inputs = self.tokenizer.batch_decode(batch.batch["prompts"], skip_special_tokens=True)
                     outputs = self.tokenizer.batch_decode(batch.batch["responses"], skip_special_tokens=True)
                     scores = batch.batch["token_level_scores"].sum(-1).cpu().tolist()
                     self._dump_generations(
                         inputs=inputs,
                         outputs=outputs,
+                        gts=None,
                         scores=scores,
                         reward_extra_infos_dict=reward_extra_infos_dict,
                         dump_path=rollout_data_dir,

--- a/contrib/agentlightning/contrib/algorithm/env_verl/trainer.py
+++ b/contrib/agentlightning/contrib/algorithm/env_verl/trainer.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import inspect
 import random
 from collections import defaultdict
 from contextlib import contextmanager
@@ -517,14 +518,20 @@ class EnvAgentLightningTrainer(RayPPOTrainer):
                     inputs = self.tokenizer.batch_decode(batch.batch["prompts"], skip_special_tokens=True)
                     outputs = self.tokenizer.batch_decode(batch.batch["responses"], skip_special_tokens=True)
                     scores = batch.batch["token_level_scores"].sum(-1).cpu().tolist()
-                    self._dump_generations(
+                    dump_kwargs = dict(
                         inputs=inputs,
                         outputs=outputs,
-                        gts=None,
                         scores=scores,
                         reward_extra_infos_dict=reward_extra_infos_dict,
                         dump_path=rollout_data_dir,
                     )
+                    # verl >=0.6.0 added a required `gts` (ground truths) parameter to
+                    # `_dump_generations`; verl 0.5.0 (CI-pinned) does not have it. Ground
+                    # truth is unavailable in agent-mode training, so feature-detect the
+                    # signature and only pass `gts=None` when the parameter exists.
+                    if "gts" in inspect.signature(self._dump_generations).parameters:
+                        dump_kwargs["gts"] = None
+                    self._dump_generations(**dump_kwargs)
 
         # compute training metrics
         metrics.update(compute_data_metrics(batch=batch, use_critic=self.use_critic, suffix="_after_processing"))


### PR DESCRIPTION
## Summary

- Fix a runtime `TypeError` in `_dump_generations()` that occurs when `rollout_data_dir` is configured, in both `AgentLightningTrainer._train_step` and `EnvAgentLightningTrainer._train_step`
- Make the fix **version-robust** across verl 0.5.0 and 0.6.0 (see Problem below)
- Remove a leftover `print(batch.batch.keys())` debug statement from both call sites

> **Note:** This PR supersedes the duplicate PRs #493 and #522, which addressed the same bug. This version additionally handles the verl 0.5.0 / 0.6.0 signature difference so it does not break the CI-pinned verl 0.5.0.

## Problem

`RayPPOTrainer._dump_generations()` is called from both trainer subclasses, but its signature changed between verl releases:

- **verl 0.5.0** (CI-pinned in `examples-compat.yml`): `_dump_generations(self, inputs, outputs, scores, reward_extra_infos_dict, dump_path)` — **no** `gts` parameter
- **verl >=0.6.0**: `_dump_generations(self, inputs, outputs, gts, scores, reward_extra_infos_dict, dump_path)` — adds a required `gts` (ground truths) positional parameter

The original call sites omitted `gts` entirely, which raises a `TypeError` on verl 0.6.0:

```
TypeError: RayPPOTrainer._dump_generations() missing 1 required positional argument: 'gts'
```

Conversely, unconditionally passing `gts=None` breaks on verl 0.5.0:

```
TypeError: _dump_generations() got an unexpected keyword argument 'gts'
```

Ground truth is not available in agent-mode training, so `None` is the correct value when the parameter exists.

## Fix

Feature-detect the `_dump_generations` signature with `inspect.signature(...)` and only pass `gts=None` when the `gts` parameter is present. This works on both verl 0.5.0 and 0.6.0:

```python
dump_kwargs = dict(
    inputs=inputs,
    outputs=outputs,
    scores=scores,
    reward_extra_infos_dict=reward_extra_infos_dict,
    dump_path=rollout_data_dir,
)
if "gts" in inspect.signature(self._dump_generations).parameters:
    dump_kwargs["gts"] = None
self._dump_generations(**dump_kwargs)
```

Fixes #492

## Files Changed

- `agentlightning/verl/trainer.py` — `AgentLightningTrainer._train_step`
- `contrib/agentlightning/contrib/algorithm/env_verl/trainer.py` — `EnvAgentLightningTrainer._train_step`

## Test plan

- [ ] Run training with `rollout_data_dir` configured on **verl 0.5.0** — no `TypeError`
- [ ] Run training with `rollout_data_dir` configured on **verl 0.6.0** — no `TypeError`, `gts=None` passed
- [ ] Run training without `rollout_data_dir` — no behavior change
