### PR TITLE
fix: resolve pyright type errors in weave instrumentation

### DIFF
--- a/agentlightning/instrumentation/weave.py
+++ b/agentlightning/instrumentation/weave.py
@@ -303,8 +303,10 @@ class InMemoryWeaveTraceServer(TraceServerClientInterface):
 
     # --- OTEL API ---
 
-    def otel_export(self, req: tsi.OtelExportReq) -> tsi.OtelExportRes:
-        return tsi.OtelExportRes()
+    def otel_export(self, req: Any) -> Any:
+        # OtelExportReq/OtelExportRes were removed from tsi in newer weave versions.
+        # Use Any to maintain backward compatibility across weave releases.
+        return None
 
     # ==========================================
     # Object Interface (V2 APIs)
@@ -463,6 +465,13 @@ class InMemoryWeaveTraceServer(TraceServerClientInterface):
         raise NotImplementedError()
 
     def calls_usage(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError()
+
+    # Methods added in newer weave releases to satisfy the abstract interface.
+    def annotation_queue_delete(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError()
+
+    def eval_results_query(self, *args: Any, **kwargs: Any) -> Any:
         raise NotImplementedError()
 
 

--- a/agentlightning/instrumentation/weave.py
+++ b/agentlightning/instrumentation/weave.py
@@ -471,6 +471,9 @@ class InMemoryWeaveTraceServer(TraceServerClientInterface):
     def annotation_queue_delete(self, *args: Any, **kwargs: Any) -> Any:
         raise NotImplementedError()
 
+    def annotation_queue_update(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError()
+
     def eval_results_query(self, *args: Any, **kwargs: Any) -> Any:
         raise NotImplementedError()
 


### PR DESCRIPTION
## Summary

- Fix `otel_export` method signature to use `Any` types instead of removed `OtelExportReq`/`OtelExportRes` types
- Add missing abstract method stubs (`annotation_queue_delete`, `annotation_queue_update`, `eval_results_query`) to `InMemoryWeaveTraceServer`

## Problem

After running `uv upgrade`, pyright reports 10 errors in the weave instrumentation:

1. `OtelExportReq` and `OtelExportRes` are no longer attributes of `weave.trace_server.trace_server_interface` in newer weave versions, causing 6 type errors in `instrumentation/weave.py`
2. `WeaveTracerManagedTraceServer` cannot be instantiated because its parent `InMemoryWeaveTraceServer` is missing abstract methods added in newer weave releases (`eval_results_query`, `annotation_queue_delete`, `annotation_queue_update`), causing 1 `reportAbstractUsage` error in `tracer/weave.py`

Both fixes maintain backward compatibility — the `Any` types work with both old and new weave versions, and the new stubs follow the existing `NotImplementedError` pattern for unsupported experimental APIs.

Fixes #496

## Test plan

- [ ] `uv run pyright -p pyrightconfig.json` passes with 0 errors in weave files
- [ ] Existing weave instrumentation tests still pass
- [ ] `InMemoryWeaveTraceServer` and `WeaveTracerManagedTraceServer` can be instantiated without `TypeError`