### PR TITLE
docs: add Claude Code CLI instructions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,13 @@
-AGENTS.md
+# Claude Code Instructions
+
+You are working in the `agent-lightning` repository.
+
+**CRITICAL INSTRUCTION:** 
+Before making any changes to the codebase, you MUST read the `AGENTS.md` file located in the root directory. 
+It contains all the essential rules for:
+- Build, Test, and Development Commands
+- Architecture Overview
+- Coding Style & Naming Conventions
+- Testing Guidelines
+
+Always adhere strictly to the guidelines specified in `AGENTS.md`.


### PR DESCRIPTION
Updates the existing CLAUDE.md to explicitly instruct the Claude Code CLI to read `AGENTS.md` before making any codebase changes. This ensures the AI has full context on architecture, styling, and testing without duplicating the rules across multiple files.

Fixes #510
