### PR TITLE
fix: prune deleted rollouts from terminal completion log

### DIFF
--- a/agentlightning/server/routes/rollouts.py
+++ b/agentlightning/server/routes/rollouts.py
@@ -218,5 +218,6 @@ async def delete_rollout(rollout_id: str) -> None:
     """Delete a rollout and its events. Idempotent: missing id is a no-op."""
     _rollouts.pop(rollout_id, None)
     _events.pop(rollout_id, None)
+    _terminal_order[:] = [rid for rid in _terminal_order if rid != rollout_id]
 
 

--- a/tests/server/test_endpoints.py
+++ b/tests/server/test_endpoints.py
@@ -394,3 +394,36 @@ def test_terminal_rollouts_cursor_pagination(client: TestClient, auth_headers: d
     page3 = client.get("/api/rollouts/terminal", params={"after": 3}, headers=auth_headers)
     assert page3.json() == {"items": [], "next_after": 3, "total_terminal": 3}
     assert pending not in {it["rollout_id"] for it in body1["items"] + body2["items"]}
+
+
+def test_delete_removes_completed_rollout_from_terminal_log(client: TestClient, auth_headers: dict[str, str]):
+    rid_a = _terminal(client, auth_headers, "a", is_train=True)
+    rid_b = _terminal(client, auth_headers, "b", is_train=False)
+
+    assert client.delete(f"/api/rollouts/{rid_a}", headers=auth_headers).status_code == 204
+
+    body = client.get("/api/rollouts/terminal", params={"after": 0}, headers=auth_headers).json()
+    assert body == {
+        "items": [{"rollout_id": rid_b, "state": "succeeded", "data_id": "b", "is_train": False}],
+        "next_after": 1,
+        "total_terminal": 1,
+    }
+
+
+def test_delete_and_reenqueue_completion_is_logged_once(client: TestClient, auth_headers: dict[str, str]):
+    rid = _terminal(client, auth_headers, "a", is_train=True)
+    assert client.delete(f"/api/rollouts/{rid}", headers=auth_headers).status_code == 204
+
+    recreated = client.post(
+        "/api/rollouts", json=[{"rollout_id": rid, "input": {"data_id": "a"}}], headers=auth_headers
+    )
+    assert recreated.status_code == 201
+    assert recreated.json()[0]["rollout_id"] == rid
+    for state in ("running", "succeeded"):
+        resp = client.patch(f"/api/rollouts/{rid}", json={"status": {"state": state}}, headers=auth_headers)
+        assert resp.status_code == 200
+
+    body = client.get("/api/rollouts/terminal", params={"after": 0}, headers=auth_headers).json()
+    assert body["total_terminal"] == 1
+    ids = [it["rollout_id"] for it in body["items"]]
+    assert ids == [rid]


### PR DESCRIPTION
## Description

delete_rollout (agentlightning/server/routes/rollouts.py:216) pops the rollout from _rollouts and _events but never removes its id from _terminal_order. The append-only completion log backing cursor pagination. 

## Consequences:
- GET /api/rollouts/terminal reports total_terminal/next_after for rollouts that no longer exist.
- Re-enqueueing a deleted client-assigned rollout_id and driving it terminal again appends a duplicate entry.
- Breaks the documented invariant next_after == total_terminal when caught up (asserted at tests/server/test_endpoints.py:395).

## Fix (root cause, not symptom)
In delete_rollout, also prune the completion log:

```
if rollout_id in _terminal_order:
    _terminal_order.remove(rollout_id)
```

Removing from the list shifts subsequent indices, which is exactly what keeps the cursor consistent. This also fixes the re-enqueue case: after delete prunes the id, re-completion appends exactly once.

## Tests
Added two regression tests in tests/server/test_endpoints.py:
- test_delete_removes_completed_rollout_from_terminal_log: delete a completed rollout, then total_terminal/next_after drop to 1 and only the surviving id is returned.
- test_delete_and_reenqueue_completion_is_logged_once: delete, re-enqueue with the same id, re-complete → logged exactly once.

## Verification
- uv run pytest → 51 passed, 3 skipped (no regressions; new tests included).
- uv run ruff check agentlightning/server/routes/rollouts.py tests/server/test_endpoints.py → only 2 pre-existing E501 (line-too-long) at test_endpoints.py:363-364 in the untouched _terminal helper; my additions are clean.
- uv run ruff format --check on the two changed files → my additions are format-clean; the only remaining diff is pre-existing style drift in the _terminal helper and cursor test.

## Note on pre-existing repo-wide failures (out of scope, not introduced here)
The repo does not currently pass its own lint/format gates cleanly. These are pre-existing and unrelated to this change; I deliberately left them untouched to keep the diff minimal:
- uv run ruff check . → 601 errors across the repo, dominated by W293 (whitespace, 411), E501 (line-too-long, 99), I001 (import sorting, 20), F541 (f-string without placeholders, 17), F401 (unused imports, 16), plus E402, F841, E001, W291, W292, F100, etc.
- uv run ruff format --check . → 51 files would be reformatted (44 already clean).
- uv run pyright → not installed in the dev toolchain (pyright is not a dev dependency in pyproject.toml); uvx pyright only reports reportMissingImports for fastapi/pydantic/httpx because of its isolated env, not real type errors.
There is no CONTRIBUTING doc, no .pre-commit-config.yaml, and no CI lint/test workflow in this repo (only docs + skills deploy workflows), so these are the only gates available.