### PR TITLE
Validate every skill, including .agents/skills, in CI

### DIFF
--- a/.github/workflows/skills.yml
+++ b/.github/workflows/skills.yml
@@ -1,4 +1,4 @@
-name: Validate Agent Lightning Skill
+name: Validate Agent Skills
 
 permissions:
   contents: read
@@ -8,11 +8,13 @@ on:
     branches: [main]
     paths:
       - 'skills/**'
+      - '.agents/skills/**'
       - '.github/workflows/skills.yml'
   pull_request:
     branches: [main]
     paths:
       - 'skills/**'
+      - '.agents/skills/**'
       - '.github/workflows/skills.yml'
   workflow_dispatch:
 
@@ -25,9 +27,40 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       - name: Validate Agent Skills format
-        run: uvx --from 'skills-ref==0.1.1' agentskills validate skills/agent-lightning
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Published skills live in skills/ and repository-local agent skills in
+          # .agents/skills/. Both use the <root>/<name>/SKILL.md layout.
+          mapfile -t SKILLS < <(
+            find skills .agents/skills -mindepth 2 -maxdepth 2 -name SKILL.md -printf '%h\n' | sort
+          )
+          if [ "${#SKILLS[@]}" -eq 0 ]; then
+            echo "No SKILL.md found under skills/ or .agents/skills/." >&2
+            exit 1
+          fi
+          for SKILL in "${SKILLS[@]}"; do
+            echo "::group::${SKILL}"
+            uvx --from 'skills-ref==0.1.1' agentskills validate "${SKILL}"
+            echo "::endgroup::"
+          done
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '22'
-      - name: Validate Claude Code plugin
-        run: npx --yes @anthropic-ai/claude-code@2.1.218 plugin validate skills/agent-lightning
+      - name: Validate Claude Code plugins
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t PLUGINS < <(
+            find skills .agents/skills -mindepth 1 -maxdepth 1 -type d \
+              -exec test -f '{}/.claude-plugin/plugin.json' \; -print | sort
+          )
+          if [ "${#PLUGINS[@]}" -eq 0 ]; then
+            echo "No Claude Code plugin found under skills/ or .agents/skills/." >&2
+            exit 1
+          fi
+          for PLUGIN in "${PLUGINS[@]}"; do
+            echo "::group::${PLUGIN}"
+            npx --yes @anthropic-ai/claude-code@2.1.218 plugin validate "${PLUGIN}"
+            echo "::endgroup::"
+          done


### PR DESCRIPTION
Follow-up to #549, split out from #550 so the workflow change lands on its own.

## Problem

`skills.yml` filtered on `skills/**` and validated the hardcoded path
`skills/agent-lightning`. The release skill added in #549 lives in
`.agents/skills/release/`, so it was outside both the trigger and the validated
path — the job did not run for it, and would not have run for any future skill
added under either root.

## Change

- Add `.agents/skills/**` to the `push` and `pull_request` path filters.
- Discover skills instead of naming one: validate every `<root>/<name>/SKILL.md`
  under `skills/` and `.agents/skills/` with the Agent Skills validator.
- Run the Claude Code plugin validator on every directory that actually carries
  `.claude-plugin/plugin.json`, rather than assuming `skills/agent-lightning` is
  the only one. Today it still resolves to exactly that directory.
- Both steps exit non-zero when discovery finds nothing, so a layout change
  cannot quietly turn the job into a no-op.

`-mindepth`/`-maxdepth` keep discovery to the spec's `<root>/<name>/SKILL.md`
layout, so a `SKILL.md` nested inside a skill's own reference material is not
picked up as a separate skill.

## Validation

Both step bodies were run verbatim against a clean checkout:

- Agent Skills validator: `Valid skill: .agents/skills/release` and
  `Valid skill: skills/agent-lightning`.
- Plugin validator: discovers `skills/agent-lightning` and passes, with the same
  pre-existing warning about no `version` in `plugin.json` as before this change.
- Negative case: a deliberately malformed skill dropped under `.agents/skills/`
  fails the loop with exit 1, confirming the new coverage is not vacuous.

## Note

The workflow's `name:` was `Validate Agent Lightning Skill`, which described the
single skill it used to check; it is now `Validate Agent Skills`. The job name,
which is what appears as the check, is unchanged. Happy to drop the rename if
anything references the old workflow title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnuugZnz2GXy8F78zkSmcY