### PR TITLE
Add complete PyPI project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,22 @@
 name = "agentlightning"
 version = "1.0.0"
 description = "Agent Lightning — agentic RL infrastructure"
+readme = "README.md"
+license = "MIT"
+authors = [
+    { name = "Agent-lightning Team" },
+]
+keywords = ["agentic-ai", "ai-agents", "reinforcement-learning"]
+classifiers = [
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
 requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.115.0",
@@ -32,6 +48,12 @@ dev = [
 [project.scripts]
 agl-server = "agentlightning.server.__main__:main"
 agl-controller = "agentlightning.controller.__main__:main"
+
+[project.urls]
+Homepage = "https://github.com/microsoft/agent-lightning"
+Documentation = "https://microsoft.github.io/agent-lightning/stable/"
+Repository = "https://github.com/microsoft/agent-lightning"
+Issues = "https://github.com/microsoft/agent-lightning/issues"
 
 [tool.uv.sources]
 torch = [

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,8 +1,8 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-"""Package rename and application metadata smoke tests."""
+"""Package and application metadata smoke tests."""
 
-from importlib.metadata import version
+from importlib.metadata import metadata, version
 
 from fastapi.testclient import TestClient
 
@@ -12,6 +12,23 @@ from agentlightning.server.app import create_app
 
 def test_package_version() -> None:
     assert __version__ == version("agentlightning")
+
+
+def test_package_metadata() -> None:
+    package_metadata = metadata("agentlightning")
+
+    assert package_metadata["Author"] == "Agent-lightning Team"
+    assert package_metadata["Description-Content-Type"] == "text/markdown"
+    assert package_metadata["License-Expression"] == "MIT"
+    long_description = package_metadata.json["description"]
+    assert isinstance(long_description, str)
+    assert long_description.startswith('<p align="center">')
+    assert set(package_metadata.get_all("Project-URL") or []) == {
+        "Documentation, https://microsoft.github.io/agent-lightning/stable/",
+        "Homepage, https://github.com/microsoft/agent-lightning",
+        "Issues, https://github.com/microsoft/agent-lightning/issues",
+        "Repository, https://github.com/microsoft/agent-lightning",
+    }
 
 
 def test_server_metadata() -> None:


### PR DESCRIPTION
## Summary

- publish README.md as the PyPI long description
- add author, SPDX license, keywords, classifiers, and project URLs
- add regression coverage for the installed distribution metadata

## Verification

- uv lock --check
- package version and metadata tests
- Ruff check and format check
- pre-commit checks for the changed files
- uv build --no-sources
- twine check for the wheel and source distribution