### PR TITLE
Ignore installed Agent Lightning skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,7 @@ venv.bak/
 .claude/
 auto_docs/
 .agents/skills/agent-lightning/
+.claude/skills/agent-lightning/
 
 # Spyder project settings
 .spyderproject

--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,7 @@ env.bak/
 venv.bak/
 .claude/
 auto_docs/
+.agents/skills/agent-lightning/
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
## Summary

- ignore the local `.agents/skills/agent-lightning/` installation used by Codex and other shared-skill agents
- explicitly ignore Claude Code’s `.claude/skills/agent-lightning/` installation
- keep the canonical `skills/agent-lightning/` source tracked

## Verification

- installed the local skill for Claude Code in a temporary repository and confirmed the `.claude/skills/agent-lightning/` destination
- `git check-ignore -v --no-index .agents/skills/agent-lightning/SKILL.md .claude/skills/agent-lightning/SKILL.md`
- `uv run pre-commit run --files .gitignore`