### PR TITLE
Fix documentation version menu stacking

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -69,8 +69,6 @@
   background-color: #FFD15D18;
   padding: 1em;
   font-weight: 500;
-  position: relative;
-  z-index: 1000;
   border: 2px solid #FFD15D;
   border-radius: 0.25em;
   margin-bottom: 2em;


### PR DESCRIPTION
## Summary

- remove the warning banner stacking context that painted above the documentation version menu
- keep the version list readable while preserving the existing banner layout and styling

## Verification

- `uv run --locked --no-sync mkdocs build --strict`
- `uv run --locked --no-sync pre-commit run --all-files --show-diff-on-failure`
- visually verified and independently reviewed with the version menu open at 1024×720 and 771×405

Fixes #570