### PR TITLE
fix(controller): avoid spawning rollouts during shutdown

### DIFF
--- a/agentlightning/controller/local_reconciler.py
+++ b/agentlightning/controller/local_reconciler.py
@@ -126,7 +126,7 @@ class LocalReconciler:
             except TimeoutError:
                 pass
 
-    async def _reconcile_once(self) -> None:
+    async def _reconcile_once(self, *, spawn_queued: bool = True) -> None:
         params = httpx.QueryParams()
         params = params.add("state_in", RolloutState.QUEUING.value)
         params = params.add("state_in", RolloutState.RUNNING.value)
@@ -141,7 +141,12 @@ class LocalReconciler:
             item = self._rid_to_proc.get(rollout.rollout_id)
 
             if item is None:
-                if rollout.status.state == RolloutState.QUEUING and live_count < self._pool_size:
+                if (
+                    spawn_queued
+                    and not self._stop.is_set()
+                    and rollout.status.state == RolloutState.QUEUING
+                    and live_count < self._pool_size
+                ):
                     if await self._spawn_for(rollout):
                         live_count += 1
                 elif rollout.status.state == RolloutState.RUNNING:
@@ -249,7 +254,7 @@ class LocalReconciler:
     async def _shutdown(self) -> None:
         """Kill live subprocesses and mark them failed."""
         try:
-            await self._reconcile_once()
+            await self._reconcile_once(spawn_queued=False)
         except Exception:
             log.exception("Final reconcile during shutdown failed")
 

--- a/tests/controller/test_local_reconciler.py
+++ b/tests/controller/test_local_reconciler.py
@@ -1,0 +1,102 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Unit tests for local subprocess reconciliation."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from omegaconf import OmegaConf
+
+from agentlightning.client import AgentLightningAsyncClient
+from agentlightning.controller.local_reconciler import LocalReconciler
+from agentlightning.schemas import Rollout, RolloutConfig, RolloutLifecycleStatus, RolloutState
+
+
+def _response(json: object) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json=json,
+        request=httpx.Request("GET", "http://server/api/rollouts"),
+    )
+
+
+def _reconciler(*, state: RolloutState = RolloutState.QUEUING) -> tuple[LocalReconciler, AsyncMock]:
+    rollout = Rollout(
+        rollout_id="rollout-1",
+        input={"question": "1 + 1"},
+        config=RolloutConfig(),
+        status=RolloutLifecycleStatus(state=state, created_at=1.0, updated_at=1.0),
+    )
+    api = AsyncMock(spec=AgentLightningAsyncClient)
+    api.get.return_value = _response([rollout.model_dump(mode="json")])
+    api.patch.return_value = _response({})
+    config = OmegaConf.create(
+        {
+            "runner_type": "local",
+            "local_runner": {"maximum_size": 1, "poll_interval": 0.01},
+        }
+    )
+    return LocalReconciler(api, config), api
+
+
+@pytest.mark.asyncio
+async def test_shutdown_does_not_spawn_queued_rollouts(monkeypatch: pytest.MonkeyPatch) -> None:
+    reconciler, api = _reconciler()
+    spawn_for = AsyncMock(return_value=True)
+    monkeypatch.setattr(reconciler, "_spawn_for", spawn_for)
+
+    await reconciler._shutdown()
+
+    spawn_for.assert_not_awaited()
+    api.patch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_normal_reconcile_still_spawns_queued_rollouts(monkeypatch: pytest.MonkeyPatch) -> None:
+    reconciler, _ = _reconciler()
+    spawn_for = AsyncMock(return_value=True)
+    monkeypatch.setattr(reconciler, "_spawn_for", spawn_for)
+
+    await reconciler._reconcile_once()
+
+    spawn_for.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_does_not_spawn_after_stop_requested_during_poll(monkeypatch: pytest.MonkeyPatch) -> None:
+    reconciler, api = _reconciler()
+    spawn_for = AsyncMock(return_value=True)
+    monkeypatch.setattr(reconciler, "_spawn_for", spawn_for)
+    get_started = asyncio.Event()
+    release_get = asyncio.Event()
+    response = api.get.return_value
+
+    async def delayed_get(*args: object, **kwargs: object) -> httpx.Response:
+        del args, kwargs
+        get_started.set()
+        await release_get.wait()
+        return response
+
+    api.get.side_effect = delayed_get
+    reconcile = asyncio.create_task(reconciler._reconcile_once())
+    await get_started.wait()
+
+    reconciler.stop()
+    release_get.set()
+    await reconcile
+
+    spawn_for.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_still_fails_running_rollout_without_local_process() -> None:
+    reconciler, api = _reconciler(state=RolloutState.RUNNING)
+
+    await reconciler._shutdown()
+
+    assert api.patch.await_args.kwargs["json"]["status"] == {
+        "state": "failed",
+        "error_message": "local subprocess is not running",
+    }


### PR DESCRIPTION
## Summary

- prevent the final shutdown reconciliation from starting queued rollouts
- honor a stop request that arrives while the rollout listing is in flight
- preserve ordinary queued spawning and final handling of already-running records

## Problem

`run()` calls `_shutdown()` from its `finally` block, and `_shutdown()` previously called the ordinary `_reconcile_once()`. That reconciliation could start queued work after shutdown had begun, only for the same shutdown path to terminate it immediately. A normal reconciliation already waiting for the rollout listing could also start queued work after `stop()` was called.

The change makes queued admission an explicit option on `_reconcile_once()`, disables it for the final shutdown pass, and checks the stop event at the queued-spawn boundary.

Closes #579

## Verification

- `uv run --extra dev pytest tests/controller/test_local_reconciler.py -q` — 4 passed
- `uv run --extra dev pytest tests/controller -q` — 96 passed
- `pyright` — 0 errors
- `ruff check .`
- `ruff format --check .`
- `python scripts/check_headers.py`
- `uv build --no-sources`

The two new shutdown/stop regressions fail on current `main`; the normal-reconcile and orphaned-running controls pass on both versions.