### PR TITLE
fix(controller): fail fast for local runner on native Windows

### DIFF
--- a/agentlightning/controller/local_reconciler.py
+++ b/agentlightning/controller/local_reconciler.py
@@ -28,6 +28,10 @@ log = structlog.get_logger()
 _SHUTDOWN_WAIT_TIMEOUT = 5.0
 
 
+def _is_native_windows() -> bool:
+    return os.name == "nt"
+
+
 def _run_local_reconciler_worker(agent_class_path: str) -> int:
     try:
         if ":" in agent_class_path:
@@ -105,6 +109,10 @@ class LocalReconciler:
         self._stop = asyncio.Event()
 
     async def run(self) -> None:
+        if _is_native_windows():
+            raise RuntimeError(
+                "runner_type=local is not supported on native Windows; use Linux (for example, WSL) instead."
+            )
         log.info("LocalReconciler starting", pool_size=self._pool_size, tick=self._tick_interval)
         try:
             await self._reconcile_loop()

--- a/docs/01-quick-start.md
+++ b/docs/01-quick-start.md
@@ -7,6 +7,8 @@ This quick start requires only one machine with one A100 GPU. It runs Agent Ligh
 Complete [Installation](00-installation.md), including the `verl` GPU stack.
 
 > AGL v1.0 itself is lightweight, but policy inference and GRPO updates still require the GPU stack used by `verl` and vLLM.
+>
+> This quick start uses `runner_type=local`, which is not supported on native Windows. On Windows, run it from a Linux environment such as WSL. See [Local runner limits](30-controller-configuration.md#local-runner-limits) for details.
 
 ## 1. Prepare the example
 

--- a/docs/30-controller-configuration.md
+++ b/docs/30-controller-configuration.md
@@ -86,6 +86,8 @@ The local runner limits concurrent processes and periodically synchronizes their
 
 When the process pool reaches `maximum_size`, queued rollouts wait until capacity becomes available.
 
+**Platform support:** The local runner requires POSIX process-group signals, so `runner_type=local` is not supported on native Windows. The Controller exits at startup, before it queries or dispatches any rollouts. Run the local controller from Linux (for example, WSL) instead; `runner_type=k8s` is unaffected.
+
 ## How agents are launched
 
 In `k8s` mode, the Controller reads the Jinja Job template stored in each rollout. The template originates from `agentlightning.k8s.job_template_path` in the Trainer configuration. The Controller renders the template with the rollout's `input`, applies the Controller settings such as namespace, timeout, and cleanup TTL, and submits the resulting Kubernetes Job. It also injects rollout-specific `AGL_OPENAI_BASE_URL`, `AGL_EVENT_URL`, and `AGL_KEY` values into every container. See [Trainer Configuration](20-trainer-configuration.md#rollout-execution) for the template configuration and Jinja examples, and `agentlightning/controller/k8s_reconciler.py` for the implementation.

--- a/tests/controller/test_local_reconciler_platform.py
+++ b/tests/controller/test_local_reconciler_platform.py
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Platform support tests for the local reconciler."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from omegaconf import OmegaConf
+
+from agentlightning.client import AgentLightningAsyncClient
+from agentlightning.controller import local_reconciler
+from agentlightning.controller.local_reconciler import LocalReconciler
+
+
+@pytest.mark.asyncio
+async def test_run_fails_before_reconciling_or_spawning_on_native_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = AsyncMock(spec=AgentLightningAsyncClient)
+    config = OmegaConf.create(
+        {
+            "runner_type": "local",
+            "local_runner": {"maximum_size": 1, "poll_interval": 0.01},
+        }
+    )
+    reconciler = LocalReconciler(api, config)
+    reconcile_loop = AsyncMock()
+    shutdown = AsyncMock()
+    monkeypatch.setattr(reconciler, "_reconcile_loop", reconcile_loop)
+    monkeypatch.setattr(reconciler, "_shutdown", shutdown)
+    monkeypatch.setattr(local_reconciler, "_is_native_windows", lambda: True)
+
+    with pytest.raises(RuntimeError, match="runner_type=local is not supported on native Windows"):
+        await reconciler.run()
+
+    reconcile_loop.assert_not_awaited()
+    shutdown.assert_not_awaited()
+    api.get.assert_not_awaited()
+    api.patch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_reconciles_and_shuts_down_on_supported_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    api = AsyncMock(spec=AgentLightningAsyncClient)
+    config = OmegaConf.create(
+        {
+            "runner_type": "local",
+            "local_runner": {"maximum_size": 1, "poll_interval": 0.01},
+        }
+    )
+    reconciler = LocalReconciler(api, config)
+    reconcile_loop = AsyncMock()
+    shutdown = AsyncMock()
+    monkeypatch.setattr(reconciler, "_reconcile_loop", reconcile_loop)
+    monkeypatch.setattr(reconciler, "_shutdown", shutdown)
+    monkeypatch.setattr(local_reconciler, "_is_native_windows", lambda: False)
+
+    await reconciler.run()
+
+    reconcile_loop.assert_awaited_once_with()
+    shutdown.assert_awaited_once_with()


### PR DESCRIPTION
Closes #578

## Summary

- `LocalReconciler.run()` now raises a clear unsupported-platform `RuntimeError` on native Windows before it queries rollouts, spawns a worker, or enters shutdown.
- Add regression tests for the Windows rejection path and for the supported-platform path.
- Document the constraint in the controller configuration reference and the quick start, and point Windows users to WSL.

## Problem

The local runner relies on POSIX process-group semantics: workers are spawned with `start_new_session=True` and cleaned up with `os.killpg()`. On native Windows `os.killpg` does not exist, so a timed-out rollout or a controller shutdown raised `AttributeError` from the cleanup path after the worker had already been spawned, and the rollout was never patched to its intended failed state.

Per the discussion in #578, native Windows is not a maintained platform for the local runner. This PR therefore does not attempt Windows process-tree cleanup. It makes the unsupported configuration fail at startup with an actionable message instead of failing later inside cleanup.

## What changed

- `agentlightning/controller/local_reconciler.py`: add `_is_native_windows()` (`os.name == 'nt'`, so WSL is unaffected) and check it at the top of `run()`. Construction, package import, and `runner_type=k8s` are unchanged.
- `tests/controller/test_local_reconciler_platform.py`: on native Windows, `run()` raises and neither `_reconcile_loop`, `_shutdown`, nor any client `get`/`patch` call is awaited; on a supported platform, `run()` still reconciles and shuts down.
- `docs/30-controller-configuration.md`: add a platform-support note under *Local runner limits*.
- `docs/01-quick-start.md`: add an early pointer to that note, since the quick start uses `runner_type=local`.

Not changed: the `Operating System :: OS Independent` classifier. The package remains importable and other runner types remain available on Windows; only the local subprocess runner is rejected. This PR does not claim Windows support for the local runner.

## Verification

- Native Windows 11, Python 3.12: `python -m agentlightning.controller runner_type=local agl_server.url=http://127.0.0.1:9` exits with code 1 and prints `RuntimeError: runner_type=local is not supported on native Windows; use Linux (for example, WSL) instead.` No request reaches the server before the error.
- `uv run --locked --no-sync pytest -q tests/controller` - 9 passed
- `uv run --locked --no-sync pytest -q tests --ignore=tests/verl` - 66 passed (the `tests/verl` modules need the `verl-cpu` group, which is not installed locally; no VERL code is touched)
- `ruff check .` and `ruff format --check .` - clean
- `pre-commit run --all-files` and `python scripts/check_headers.py` - passed
- `pyright --pythonplatform Linux` on the changed files - 0 errors. On a Windows host, pyright reports the pre-existing `os.killpg` / `signal.SIGKILL` stubs at the cleanup site; the same findings exist on `main`.
- `mkdocs build --strict` - passed; the `#local-runner-limits` anchor resolves
- `uv build --no-sources` - sdist and wheel built