### PR TITLE
fix(client): replace authorization headers case-insensitively

### DIFF
--- a/agentlightning/client.py
+++ b/agentlightning/client.py
@@ -10,8 +10,8 @@ from typing import Any
 import httpx
 
 
-def _headers_with_key(headers: httpx.Headers | dict[str, str] | None, key: str | None) -> dict[str, str]:
-    merged = dict(headers or {})
+def _headers_with_key(headers: httpx.Headers | dict[str, str] | None, key: str | None) -> httpx.Headers:
+    merged = httpx.Headers(headers)
     if key:
         merged["Authorization"] = f"Bearer {key}"
     return merged

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,58 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Regression coverage for the clients' optional bearer key."""
+
+import httpx
+import pytest
+
+from agentlightning.client import AgentLightningAsyncClient, AgentLightningSyncClient
+
+
+@pytest.fixture(
+    params=[
+        {"Authorization": "Bearer old-test-key", "X-Custom": "preserved"},
+        {"authorization": "Bearer old-test-key", "X-Custom": "preserved"},
+        {"aUtHoRiZaTiOn": "Bearer old-test-key", "X-Custom": "preserved"},
+        httpx.Headers({"Authorization": "Bearer old-test-key", "X-Custom": "preserved"}),
+    ]
+)
+def headers(request: pytest.FixtureRequest) -> httpx.Headers | dict[str, str]:
+    return request.param.copy()
+
+
+def _assert_bearer(request: httpx.Request) -> httpx.Response:
+    assert request.headers.get_list("Authorization") == ["Bearer new-test-key"]
+    assert request.headers["X-Custom"] == "preserved"
+    return httpx.Response(200)
+
+
+def test_sync_key_replaces_authorization_case_insensitively(headers: httpx.Headers | dict[str, str]) -> None:
+    original = dict(headers)
+    with AgentLightningSyncClient(
+        headers=headers, key="new-test-key", max_retries=0, transport=httpx.MockTransport(_assert_bearer)
+    ) as client:
+        assert client.get("https://example.test").status_code == 200
+    assert dict(headers) == original
+
+
+@pytest.mark.asyncio
+async def test_async_key_replaces_authorization_case_insensitively(headers: httpx.Headers | dict[str, str]) -> None:
+    original = dict(headers)
+    async with AgentLightningAsyncClient(
+        headers=headers, key="new-test-key", transport=httpx.MockTransport(_assert_bearer)
+    ) as client:
+        assert (await client.get("https://example.test")).status_code == 200
+    assert dict(headers) == original
+
+
+@pytest.mark.parametrize("key", [None, ""])
+def test_sync_without_key_preserves_authorization(key: str | None) -> None:
+    with AgentLightningSyncClient(headers={"authorization": "Bearer old-test-key"}, key=key) as client:
+        assert client.headers.get_list("Authorization") == ["Bearer old-test-key"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("key", [None, ""])
+async def test_async_without_key_preserves_authorization(key: str | None) -> None:
+    async with AgentLightningAsyncClient(headers={"authorization": "Bearer old-test-key"}, key=key) as client:
+        assert client.headers.get_list("Authorization") == ["Bearer old-test-key"]


### PR DESCRIPTION
Passing an explicit bearer `key` alongside an existing lowercase or mixed-case authorization header currently sends both the old and new values. This also occurs with `httpx.Headers`, which normalizes keys to lowercase. Build the merged headers with `httpx.Headers` so the explicit key replaces any existing authorization value case-insensitively in both clients.

Tests exercise actual requests through `MockTransport`, preserve unrelated headers and the caller's header object, and retain existing authorization when no key is supplied. Six cases fail on the unchanged implementation. The client, controller, server, and package test selection passes all 46 cases; scoped Ruff, formatting, Pyright, and diff checks pass.

AI assistance: Codex helped investigate, implement, and validate this change.
